### PR TITLE
feat: pin flake-compat to specific revision for purity

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,17 @@
 # The `default.nix` in flake-compat reads `flake.nix` and `flake.lock` from `src` and
 # returns an attribute set of the shape `{ defaultNix, shellNix }`
 
-(import (fetchTarball "https://github.com/edolstra/flake-compat/archive/master.tar.gz") {
-  src = ./.;
-}).defaultNix
+let
+  lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+  inherit (lock.nodes.flake-compat.locked)
+    owner
+    repo
+    rev
+    narHash
+    ;
+  flake-compat = fetchTarball {
+    url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz";
+    sha256 = narHash;
+  };
+in
+(import flake-compat { src = ./.; }).defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1761588595,
+        "narHash": "sha256-XKUZz9zewJNUj46b4AJdiRZJAvSZ0Dqj2BNfXvFlJC4=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "f387cd2afec9419c8ee37694406ca490c3f34ee5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": [
@@ -38,6 +54,7 @@
     },
     "root": {
       "inputs": {
+        "flake-compat": "flake-compat",
         "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs",
         "systems": "systems"

--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,11 @@
       url = "github:nix-systems/default";
       flake = false;
     };
+
+    flake-compat = {
+      url = "github:edolstra/flake-compat";
+      flake = false;
+    };
   };
   outputs =
     inputs:


### PR DESCRIPTION
# Motivation

The current impure `default.nix` causes evaluation failures when used with `--flake` or in pure evaluation contexts.

When fetching from `master` without a hash:
```nix
fetchTarball "https://github.com/edolstra/flake-compat/archive/master.tar.gz"
```

Nix rejects this in pure mode because:
- `master` is a moving target
- No hash means no content verification
- Violates purity requirements for flake evaluation

This breaks workflows for users who want to import statix via classical Nix tools (npins, niv, etc.) while maintaining flake compatibility. Pure evaluation is required when using `--flake`, and impure fetches cause hard failures.

## Changes

- Added `flake-compat` to `flake.nix` inputs with `flake = false`
- Updated `flake.lock` to pin `flake-compat` version
- Modified `default.nix` to read pinned version from `flake.lock` with hash verification

## Benefits

- Works in pure evaluation mode `--flake`
- Reproducible - pins `flake-compat` to a specific version instead of following `master`