### PR TITLE
fix: prevent ariadne from panicking on empty stdin/file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,10 +69,11 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "ariadne"
-version = "0.1.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7080ae01b2f0c312065d4914cd0f0de045eb8832e9415b355106a6cff3073cb4"
+checksum = "8454c8a44ce2cb9cc7e7fae67fc6128465b343b92c6631e94beca3c8d1524ea5"
 dependencies = [
+ "unicode-width",
  "yansi",
 ]
 
@@ -826,6 +827,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1022,6 +1029,6 @@ checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "yansi"
-version = "0.5.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc79f4a1e39857fc00c3f662cbf2651c771f00e9c15fe2abc341806bd46bd71"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"

--- a/bin/src/traits.rs
+++ b/bin/src/traits.rs
@@ -67,7 +67,7 @@ fn write_stderr<T: Write>(
             .diagnostics
             .iter()
             .fold(
-                CliReport::build(report_kind, src_id, offset)
+                CliReport::build(report_kind, (src_id, offset..offset))
                     .with_config(
                         CliConfig::default()
                             .with_cross_gap(true)

--- a/bin/src/traits.rs
+++ b/bin/src/traits.rs
@@ -52,12 +52,10 @@ fn write_stderr<T: Write>(
     let range = |at: TextRange| at.start().into()..at.end().into();
     let src_id = path.to_str().unwrap_or("<unknown>");
     for report in &lint_result.reports {
-        let offset = report
-            .diagnostics
-            .iter()
-            .map(|d| d.at.start().into())
-            .min()
-            .unwrap_or(0usize);
+        let report_range = report
+            .total_diagnostic_range()
+            .map(range)
+            .unwrap_or(0usize..0usize);
         let report_kind = match report.severity {
             Severity::Warn => CliReportKind::Warning,
             Severity::Error => CliReportKind::Error,
@@ -67,7 +65,7 @@ fn write_stderr<T: Write>(
             .diagnostics
             .iter()
             .fold(
-                CliReport::build(report_kind, (src_id, offset..offset))
+                CliReport::build(report_kind, (src_id, report_range))
                     .with_config(
                         CliConfig::default()
                             .with_cross_gap(true)

--- a/bin/tests/_utils.rs
+++ b/bin/tests/_utils.rs
@@ -1,7 +1,8 @@
-use std::{io::Write, process::Command};
+use std::{io::Write, process::Command, process::Stdio};
 
 use tempfile::NamedTempFile;
 
+#[allow(dead_code)]
 pub fn test_cli(expression: &str, args: &[&str]) -> anyhow::Result<String> {
     let mut fixture = NamedTempFile::with_suffix(".nix")?;
     fixture.write_all(expression.as_bytes())?;
@@ -18,4 +19,26 @@ pub fn test_cli(expression: &str, args: &[&str]) -> anyhow::Result<String> {
     let stdout = stdout.replace(fixture.path().to_str().unwrap(), "<temp_file_path>");
 
     Ok(stdout)
+}
+
+#[allow(dead_code)]
+pub fn test_cli_stdin(input: &str, args: &[&str]) -> anyhow::Result<String> {
+    let mut child = Command::new("cargo")
+        .arg("run")
+        .arg("--")
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()?;
+
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin should be piped")
+        .write_all(input.as_bytes())?;
+
+    let output = child.wait_with_output()?;
+    let stdout = strip_ansi_escapes::strip(output.stdout)?;
+
+    Ok(String::from_utf8(stdout)?)
 }

--- a/bin/tests/empty_file.rs
+++ b/bin/tests/empty_file.rs
@@ -1,0 +1,10 @@
+mod _utils;
+
+#[test]
+fn check_empty_file_reports_parse_error() {
+    let stdout = _utils::test_cli("", &["check"]).unwrap();
+
+    assert!(stdout.contains("[00] Error: Syntax error"), "{stdout}");
+    assert!(stdout.contains("Unexpected end of file"), "{stdout}");
+    assert!(stdout.contains("<temp_file_path>:1:1"), "{stdout}");
+}

--- a/bin/tests/empty_stdin.rs
+++ b/bin/tests/empty_stdin.rs
@@ -1,0 +1,10 @@
+mod _utils;
+
+#[test]
+fn check_empty_stdin_reports_parse_error() {
+    let stdout = _utils::test_cli_stdin("", &["check", "-s"]).unwrap();
+
+    assert!(stdout.contains("[00] Error: Syntax error"), "{stdout}");
+    assert!(stdout.contains("Unexpected end of file"), "{stdout}");
+    assert!(stdout.contains("<stdin>:1:1"), "{stdout}");
+}

--- a/bin/tests/snapshots/bool_comparison__01765d342111cdd7f2f68ac70b4a9451_lint.snap
+++ b/bin/tests/snapshots/bool_comparison__01765d342111cdd7f2f68ac70b4a9451_lint.snap
@@ -3,10 +3,10 @@ source: bin/tests/bool_comparison.rs
 ---
 true != false
 ---
-[W01] Warning: Equality comparison between boolean literals
-   ╭─[<temp_file_path>:1:1]
+[01] Warning: Equality comparison between boolean literals
+   ╭─[ <temp_file_path>:1:1 ]
    │
  1 │ true != false
-   · ──────┬──────  
-   ·       ╰──────── Equality comparison between boolean literals
+   │ ──────┬──────  
+   │       ╰──────── Equality comparison between boolean literals
 ───╯

--- a/bin/tests/snapshots/bool_comparison__3fce60992c69dd4f86be49b4f2898f9e_lint.snap
+++ b/bin/tests/snapshots/bool_comparison__3fce60992c69dd4f86be49b4f2898f9e_lint.snap
@@ -3,10 +3,10 @@ source: bin/tests/bool_comparison.rs
 ---
 false != true
 ---
-[W01] Warning: Equality comparison between boolean literals
-   ╭─[<temp_file_path>:1:1]
+[01] Warning: Equality comparison between boolean literals
+   ╭─[ <temp_file_path>:1:1 ]
    │
  1 │ false != true
-   · ──────┬──────  
-   ·       ╰──────── Equality comparison between boolean literals
+   │ ──────┬──────  
+   │       ╰──────── Equality comparison between boolean literals
 ───╯

--- a/bin/tests/snapshots/bool_comparison__5d2c71eef69cc07e519dc3646f786ba7_lint.snap
+++ b/bin/tests/snapshots/bool_comparison__5d2c71eef69cc07e519dc3646f786ba7_lint.snap
@@ -3,10 +3,10 @@ source: bin/tests/bool_comparison.rs
 ---
 false == false
 ---
-[W01] Warning: Equality comparison between boolean literals
-   ╭─[<temp_file_path>:1:1]
+[01] Warning: Equality comparison between boolean literals
+   ╭─[ <temp_file_path>:1:1 ]
    │
  1 │ false == false
-   · ───────┬──────  
-   ·        ╰──────── Equality comparison between boolean literals
+   │ ───────┬──────  
+   │        ╰──────── Equality comparison between boolean literals
 ───╯

--- a/bin/tests/snapshots/bool_comparison__82b623ef0ecd1e0e70c1dbe39f028326_lint.snap
+++ b/bin/tests/snapshots/bool_comparison__82b623ef0ecd1e0e70c1dbe39f028326_lint.snap
@@ -3,10 +3,10 @@ source: bin/tests/bool_comparison.rs
 ---
 true == true
 ---
-[W01] Warning: Equality comparison between boolean literals
-   ╭─[<temp_file_path>:1:1]
+[01] Warning: Equality comparison between boolean literals
+   ╭─[ <temp_file_path>:1:1 ]
    │
  1 │ true == true
-   · ──────┬─────  
-   ·       ╰─────── Equality comparison between boolean literals
+   │ ──────┬─────  
+   │       ╰─────── Equality comparison between boolean literals
 ───╯

--- a/bin/tests/snapshots/bool_comparison__852249844e4f5e03707d323181ca8645_lint.snap
+++ b/bin/tests/snapshots/bool_comparison__852249844e4f5e03707d323181ca8645_lint.snap
@@ -3,10 +3,10 @@ source: bin/tests/bool_comparison.rs
 ---
 true != true
 ---
-[W01] Warning: Equality comparison between boolean literals
-   ╭─[<temp_file_path>:1:1]
+[01] Warning: Equality comparison between boolean literals
+   ╭─[ <temp_file_path>:1:1 ]
    │
  1 │ true != true
-   · ──────┬─────  
-   ·       ╰─────── Equality comparison between boolean literals
+   │ ──────┬─────  
+   │       ╰─────── Equality comparison between boolean literals
 ───╯

--- a/bin/tests/snapshots/bool_comparison__ba56854c55bd3954b56d4e0c3d32b65c_lint.snap
+++ b/bin/tests/snapshots/bool_comparison__ba56854c55bd3954b56d4e0c3d32b65c_lint.snap
@@ -3,10 +3,10 @@ source: bin/tests/bool_comparison.rs
 ---
 false == true
 ---
-[W01] Warning: Equality comparison between boolean literals
-   ╭─[<temp_file_path>:1:1]
+[01] Warning: Equality comparison between boolean literals
+   ╭─[ <temp_file_path>:1:1 ]
    │
  1 │ false == true
-   · ──────┬──────  
-   ·       ╰──────── Equality comparison between boolean literals
+   │ ──────┬──────  
+   │       ╰──────── Equality comparison between boolean literals
 ───╯

--- a/bin/tests/snapshots/bool_comparison__e242c6e0c4298e00ab2cae2f89de63cc_lint.snap
+++ b/bin/tests/snapshots/bool_comparison__e242c6e0c4298e00ab2cae2f89de63cc_lint.snap
@@ -3,10 +3,10 @@ source: bin/tests/bool_comparison.rs
 ---
 false != false
 ---
-[W01] Warning: Equality comparison between boolean literals
-   ╭─[<temp_file_path>:1:1]
+[01] Warning: Equality comparison between boolean literals
+   ╭─[ <temp_file_path>:1:1 ]
    │
  1 │ false != false
-   · ───────┬──────  
-   ·        ╰──────── Equality comparison between boolean literals
+   │ ───────┬──────  
+   │        ╰──────── Equality comparison between boolean literals
 ───╯

--- a/bin/tests/snapshots/bool_comparison__eb450df0fb6d76e9df94f175a6b87a7c_lint.snap
+++ b/bin/tests/snapshots/bool_comparison__eb450df0fb6d76e9df94f175a6b87a7c_lint.snap
@@ -3,10 +3,10 @@ source: bin/tests/bool_comparison.rs
 ---
 true == false
 ---
-[W01] Warning: Equality comparison between boolean literals
-   ╭─[<temp_file_path>:1:1]
+[01] Warning: Equality comparison between boolean literals
+   ╭─[ <temp_file_path>:1:1 ]
    │
  1 │ true == false
-   · ──────┬──────  
-   ·       ╰──────── Equality comparison between boolean literals
+   │ ──────┬──────  
+   │       ╰──────── Equality comparison between boolean literals
 ───╯

--- a/bin/tests/snapshots/bool_simplification__b01828755e286c145f9a8ae65cde7a14_lint.snap
+++ b/bin/tests/snapshots/bool_simplification__b01828755e286c145f9a8ae65cde7a14_lint.snap
@@ -3,10 +3,10 @@ source: bin/tests/bool_simplification.rs
 ---
 !(a == b)
 ---
-[W18] Warning: This boolean expression can be simplified
-   ╭─[<temp_file_path>:1:1]
+[18] Warning: This boolean expression can be simplified
+   ╭─[ <temp_file_path>:1:1 ]
    │
  1 │ !(a == b)
-   · ────┬────  
-   ·     ╰────── Try != instead of !(... == ...)
+   │ ────┬────  
+   │     ╰────── Try != instead of !(... == ...)
 ───╯

--- a/bin/tests/snapshots/collapsible_let_in__2e638014232f7dec2606c940ad2e97f6_lint.snap
+++ b/bin/tests/snapshots/collapsible_let_in__2e638014232f7dec2606c940ad2e97f6_lint.snap
@@ -9,14 +9,16 @@ let
 in
 x
 ---
-[W06] Warning: These let-in expressions are collapsible
-   ╭─[<temp_file_path>:1:1]
+[06] Warning: These let-in expressions are collapsible
+   ╭─[ <temp_file_path>:1:1 ]
    │
  1 │ ╭───▶ let
+   ┆ ┆     
  4 │ │ ╭─▶ let
+   ┆ ┆ ┆   
  7 │ │ ├─▶ x
-   · │ │   │   
-   · │ ╰─────── This let in expression is nested
-   · │     │   
-   · ╰─────┴─── This let in expression contains a nested let in expression
+   │ │ │   │   
+   │ │ ╰─────── This let in expression is nested
+   │ │     │   
+   │ ╰─────┴─── This let in expression contains a nested let in expression
 ───╯

--- a/bin/tests/snapshots/collapsible_let_in__950e48dec6590cd20937e48006bff3f7_lint.snap
+++ b/bin/tests/snapshots/collapsible_let_in__950e48dec6590cd20937e48006bff3f7_lint.snap
@@ -11,14 +11,16 @@ in
   in
   a + b + c + d
 ---
-[W06] Warning: These let-in expressions are collapsible
-   ╭─[<temp_file_path>:1:1]
+[06] Warning: These let-in expressions are collapsible
+   ╭─[ <temp_file_path>:1:1 ]
    │
  1 │ ╭───▶ let
+   ┆ ┆     
  5 │ │ ╭─▶   let
+   ┆ ┆ ┆   
  9 │ │ ├─▶   a + b + c + d
-   · │ │                 │   
-   · │ ╰───────────────────── This let in expression is nested
-   · │                   │   
-   · ╰───────────────────┴─── This let in expression contains a nested let in expression
+   │ │ │                 │   
+   │ │ ╰───────────────────── This let in expression is nested
+   │ │                   │   
+   │ ╰───────────────────┴─── This let in expression contains a nested let in expression
 ───╯

--- a/bin/tests/snapshots/collapsible_let_in__f9545ef768954a51771885c60c1bca1a_lint.snap
+++ b/bin/tests/snapshots/collapsible_let_in__f9545ef768954a51771885c60c1bca1a_lint.snap
@@ -9,14 +9,16 @@ let
 in
 c
 ---
-[W06] Warning: These let-in expressions are collapsible
-   ╭─[<temp_file_path>:1:1]
+[06] Warning: These let-in expressions are collapsible
+   ╭─[ <temp_file_path>:1:1 ]
    │
  1 │ ╭───▶ let
+   ┆ ┆     
  4 │ │ ╭─▶ let
+   ┆ ┆ ┆   
  7 │ │ ├─▶ c
-   · │ │   │   
-   · │ ╰─────── This let in expression is nested
-   · │     │   
-   · ╰─────┴─── This let in expression contains a nested let in expression
+   │ │ │   │   
+   │ │ ╰─────── This let in expression is nested
+   │ │     │   
+   │ ╰─────┴─── This let in expression contains a nested let in expression
 ───╯

--- a/bin/tests/snapshots/collapsible_let_in__fe25e67d93fa84cbd3753185f7f64e63_lint.snap
+++ b/bin/tests/snapshots/collapsible_let_in__fe25e67d93fa84cbd3753185f7f64e63_lint.snap
@@ -9,14 +9,16 @@ let
 in
 x
 ---
-[W06] Warning: These let-in expressions are collapsible
-   ╭─[<temp_file_path>:1:1]
+[06] Warning: These let-in expressions are collapsible
+   ╭─[ <temp_file_path>:1:1 ]
    │
  1 │ ╭───▶ let
+   ┆ ┆     
  4 │ │ ╭─▶ let
+   ┆ ┆ ┆   
  7 │ │ ├─▶ x
-   · │ │   │   
-   · │ ╰─────── This let in expression is nested
-   · │     │   
-   · ╰─────┴─── This let in expression contains a nested let in expression
+   │ │ │   │   
+   │ │ ╰─────── This let in expression is nested
+   │ │     │   
+   │ ╰─────┴─── This let in expression contains a nested let in expression
 ───╯

--- a/bin/tests/snapshots/deprecated_to_path__174dc0d1d9e78fd30b854475b82a9917_lint.snap
+++ b/bin/tests/snapshots/deprecated_to_path__174dc0d1d9e78fd30b854475b82a9917_lint.snap
@@ -3,10 +3,10 @@ source: bin/tests/deprecated_to_path.rs
 ---
 builtins.toPath "/some/path"
 ---
-[W17] Warning: Found usage of deprecated builtin toPath
-   ╭─[<temp_file_path>:1:1]
+[17] Warning: Found usage of deprecated builtin toPath
+   ╭─[ <temp_file_path>:1:1 ]
    │
  1 │ builtins.toPath "/some/path"
-   · ──────────────┬─────────────  
-   ·               ╰─────────────── builtins.toPath is deprecated, see :doc builtins.toPath within the REPL for more
+   │ ──────────────┬─────────────  
+   │               ╰─────────────── builtins.toPath is deprecated, see :doc builtins.toPath within the REPL for more
 ───╯

--- a/bin/tests/snapshots/deprecated_to_path__4f2c5321b7dbd2171c77729c879745a1_lint.snap
+++ b/bin/tests/snapshots/deprecated_to_path__4f2c5321b7dbd2171c77729c879745a1_lint.snap
@@ -3,10 +3,10 @@ source: bin/tests/deprecated_to_path.rs
 ---
 toPath x
 ---
-[W17] Warning: Found usage of deprecated builtin toPath
-   ╭─[<temp_file_path>:1:1]
+[17] Warning: Found usage of deprecated builtin toPath
+   ╭─[ <temp_file_path>:1:1 ]
    │
  1 │ toPath x
-   · ────┬───  
-   ·     ╰───── toPath is deprecated, see :doc builtins.toPath within the REPL for more
+   │ ────┬───  
+   │     ╰───── toPath is deprecated, see :doc builtins.toPath within the REPL for more
 ───╯

--- a/bin/tests/snapshots/deprecated_to_path__b7ca5bc4bbe1fe57468d47f2df8fac29_lint.snap
+++ b/bin/tests/snapshots/deprecated_to_path__b7ca5bc4bbe1fe57468d47f2df8fac29_lint.snap
@@ -3,10 +3,10 @@ source: bin/tests/deprecated_to_path.rs
 ---
 builtins.toPath x
 ---
-[W17] Warning: Found usage of deprecated builtin toPath
-   ╭─[<temp_file_path>:1:1]
+[17] Warning: Found usage of deprecated builtin toPath
+   ╭─[ <temp_file_path>:1:1 ]
    │
  1 │ builtins.toPath x
-   · ────────┬────────  
-   ·         ╰────────── builtins.toPath is deprecated, see :doc builtins.toPath within the REPL for more
+   │ ────────┬────────  
+   │         ╰────────── builtins.toPath is deprecated, see :doc builtins.toPath within the REPL for more
 ───╯

--- a/bin/tests/snapshots/deprecated_to_path__babcf3ca5fe7ee69b692a0e6ccfbfdf4_lint.snap
+++ b/bin/tests/snapshots/deprecated_to_path__babcf3ca5fe7ee69b692a0e6ccfbfdf4_lint.snap
@@ -3,10 +3,10 @@ source: bin/tests/deprecated_to_path.rs
 ---
 toPath "/abc/def"
 ---
-[W17] Warning: Found usage of deprecated builtin toPath
-   ╭─[<temp_file_path>:1:1]
+[17] Warning: Found usage of deprecated builtin toPath
+   ╭─[ <temp_file_path>:1:1 ]
    │
  1 │ toPath "/abc/def"
-   · ────────┬────────  
-   ·         ╰────────── toPath is deprecated, see :doc builtins.toPath within the REPL for more
+   │ ────────┬────────  
+   │         ╰────────── toPath is deprecated, see :doc builtins.toPath within the REPL for more
 ───╯

--- a/bin/tests/snapshots/empty_inherit__2370f348818d984736674ed594a50098_lint.snap
+++ b/bin/tests/snapshots/empty_inherit__2370f348818d984736674ed594a50098_lint.snap
@@ -3,10 +3,10 @@ source: bin/tests/empty_inherit.rs
 ---
 { inherit; }
 ---
-[W14] Warning: Found empty inherit statement
-   ╭─[<temp_file_path>:1:3]
+[14] Warning: Found empty inherit statement
+   ╭─[ <temp_file_path>:1:3 ]
    │
  1 │ { inherit; }
-   ·   ────┬───  
-   ·       ╰───── Remove this empty inherit statement
+   │   ────┬───  
+   │       ╰───── Remove this empty inherit statement
 ───╯

--- a/bin/tests/snapshots/empty_let_in__5c1128abfe4ef6b1ed846295f216703a_lint.snap
+++ b/bin/tests/snapshots/empty_let_in__5c1128abfe4ef6b1ed846295f216703a_lint.snap
@@ -3,10 +3,10 @@ source: bin/tests/empty_let_in.rs
 ---
 let in null
 ---
-[W02] Warning: Useless let-in expression
-   ╭─[<temp_file_path>:1:1]
+[02] Warning: Useless let-in expression
+   ╭─[ <temp_file_path>:1:1 ]
    │
  1 │ let in null
-   · ─────┬─────  
-   ·      ╰─────── This let-in expression has no entries
+   │ ─────┬─────  
+   │      ╰─────── This let-in expression has no entries
 ───╯

--- a/bin/tests/snapshots/empty_let_in__69e2d9e348a3b7903ae1678878867095_lint.snap
+++ b/bin/tests/snapshots/empty_let_in__69e2d9e348a3b7903ae1678878867095_lint.snap
@@ -7,11 +7,12 @@ let
 in
 null
 ---
-[W02] Warning: Useless let-in expression
-   ╭─[<temp_file_path>:1:1]
+[02] Warning: Useless let-in expression
+   ╭─[ <temp_file_path>:1:1 ]
    │
  1 │ ╭─▶ let
+   ┆ ┆   
  5 │ ├─▶ null
-   · │          
-   · ╰────────── This let-in expression has no entries
+   │ │          
+   │ ╰────────── This let-in expression has no entries
 ───╯

--- a/bin/tests/snapshots/empty_list_concat__676800f4240e26802590a123362636e6_lint.snap
+++ b/bin/tests/snapshots/empty_list_concat__676800f4240e26802590a123362636e6_lint.snap
@@ -3,10 +3,10 @@ source: bin/tests/empty_list_concat.rs
 ---
 [1 2 3] ++ []
 ---
-[W23] Warning: Unnecessary concatenation with empty list
-   ╭─[<temp_file_path>:1:1]
+[23] Warning: Unnecessary concatenation with empty list
+   ╭─[ <temp_file_path>:1:1 ]
    │
  1 │ [1 2 3] ++ []
-   · ──────┬──────  
-   ·       ╰──────── Concatenation with the empty list, [], is a no-op
+   │ ──────┬──────  
+   │       ╰──────── Concatenation with the empty list, [], is a no-op
 ───╯

--- a/bin/tests/snapshots/empty_list_concat__b13b2273654200cbc2315c6ceec0dbc9_lint.snap
+++ b/bin/tests/snapshots/empty_list_concat__b13b2273654200cbc2315c6ceec0dbc9_lint.snap
@@ -3,17 +3,17 @@ source: bin/tests/empty_list_concat.rs
 ---
 [] ++ [] ++ []
 ---
-[W23] Warning: Unnecessary concatenation with empty list
-   ╭─[<temp_file_path>:1:1]
+[23] Warning: Unnecessary concatenation with empty list
+   ╭─[ <temp_file_path>:1:1 ]
    │
  1 │ [] ++ [] ++ []
-   · ───────┬──────  
-   ·        ╰──────── Concatenation with the empty list, [], is a no-op
+   │ ───────┬──────  
+   │        ╰──────── Concatenation with the empty list, [], is a no-op
 ───╯
-[W23] Warning: Unnecessary concatenation with empty list
-   ╭─[<temp_file_path>:1:7]
+[23] Warning: Unnecessary concatenation with empty list
+   ╭─[ <temp_file_path>:1:7 ]
    │
  1 │ [] ++ [] ++ []
-   ·       ────┬───  
-   ·           ╰───── Concatenation with the empty list, [], is a no-op
+   │       ────┬───  
+   │           ╰───── Concatenation with the empty list, [], is a no-op
 ───╯

--- a/bin/tests/snapshots/empty_list_concat__b6d6b2d3b0ff0b3b842e3f816ced62ca_lint.snap
+++ b/bin/tests/snapshots/empty_list_concat__b6d6b2d3b0ff0b3b842e3f816ced62ca_lint.snap
@@ -3,10 +3,10 @@ source: bin/tests/empty_list_concat.rs
 ---
 [] ++ [1 2 3]
 ---
-[W23] Warning: Unnecessary concatenation with empty list
-   ╭─[<temp_file_path>:1:1]
+[23] Warning: Unnecessary concatenation with empty list
+   ╭─[ <temp_file_path>:1:1 ]
    │
  1 │ [] ++ [1 2 3]
-   · ──────┬──────  
-   ·       ╰──────── Concatenation with the empty list, [], is a no-op
+   │ ──────┬──────  
+   │       ╰──────── Concatenation with the empty list, [], is a no-op
 ───╯

--- a/bin/tests/snapshots/empty_list_concat__df1c6ef98c749f5c410a485b3d0d5d68_lint.snap
+++ b/bin/tests/snapshots/empty_list_concat__df1c6ef98c749f5c410a485b3d0d5d68_lint.snap
@@ -3,10 +3,10 @@ source: bin/tests/empty_list_concat.rs
 ---
 [] ++ []
 ---
-[W23] Warning: Unnecessary concatenation with empty list
-   ╭─[<temp_file_path>:1:1]
+[23] Warning: Unnecessary concatenation with empty list
+   ╭─[ <temp_file_path>:1:1 ]
    │
  1 │ [] ++ []
-   · ────┬───  
-   ·     ╰───── Concatenation with the empty list, [], is a no-op
+   │ ────┬───  
+   │     ╰───── Concatenation with the empty list, [], is a no-op
 ───╯

--- a/bin/tests/snapshots/empty_pattern__d126fd36c3561a6c02bd6635634d0261_lint.snap
+++ b/bin/tests/snapshots/empty_pattern__d126fd36c3561a6c02bd6635634d0261_lint.snap
@@ -3,10 +3,10 @@ source: bin/tests/empty_pattern.rs
 ---
 ({ ... }: 42)
 ---
-[W10] Warning: Found empty pattern in function argument
-   ╭─[<temp_file_path>:1:2]
+[10] Warning: Found empty pattern in function argument
+   ╭─[ <temp_file_path>:1:2 ]
    │
  1 │ ({ ... }: 42)
-   ·  ───┬───  
-   ·     ╰───── This pattern is empty, use _ instead
+   │  ───┬───  
+   │     ╰───── This pattern is empty, use _ instead
 ───╯

--- a/bin/tests/snapshots/empty_pattern__d258b2d28244a887c36cde36b8b3c301_lint.snap
+++ b/bin/tests/snapshots/empty_pattern__d258b2d28244a887c36cde36b8b3c301_lint.snap
@@ -3,10 +3,10 @@ source: bin/tests/empty_pattern.rs
 ---
 ({ ... } @ inputs: inputs)
 ---
-[W11] Warning: Found redundant pattern bind in function argument
-   ╭─[<temp_file_path>:1:2]
+[11] Warning: Found redundant pattern bind in function argument
+   ╭─[ <temp_file_path>:1:2 ]
    │
  1 │ ({ ... } @ inputs: inputs)
-   ·  ────────┬───────  
-   ·          ╰───────── This pattern bind is redundant, use inputs instead
+   │  ────────┬───────  
+   │          ╰───────── This pattern bind is redundant, use inputs instead
 ───╯

--- a/bin/tests/snapshots/eta_reduction__371c868dbc9581a6fc41c7085146a422_lint.snap
+++ b/bin/tests/snapshots/eta_reduction__371c868dbc9581a6fc41c7085146a422_lint.snap
@@ -3,10 +3,10 @@ source: bin/tests/eta_reduction.rs
 ---
 let double = x: x * 2; in map (x: double x) [1 2 3]
 ---
-[W07] Warning: This function expression is eta reducible
-   ╭─[<temp_file_path>:1:32]
+[07] Warning: This function expression is eta reducible
+   ╭─[ <temp_file_path>:1:32 ]
    │
  1 │ let double = x: x * 2; in map (x: double x) [1 2 3]
-   ·                                ─────┬─────  
-   ·                                     ╰─────── Found eta-reduction: double
+   │                                ─────┬─────  
+   │                                     ╰─────── Found eta-reduction: double
 ───╯

--- a/bin/tests/snapshots/legacy_let_syntax__7b38199c6c6f7f991caca355bdf9d4eb_lint.snap
+++ b/bin/tests/snapshots/legacy_let_syntax__7b38199c6c6f7f991caca355bdf9d4eb_lint.snap
@@ -7,11 +7,12 @@ let {
   y = " world!";
 }
 ---
-[W05] Warning: Using undocumented `let` syntax
-   ╭─[<temp_file_path>:1:1]
+[05] Warning: Using undocumented `let` syntax
+   ╭─[ <temp_file_path>:1:1 ]
    │
  1 │ ╭─▶ let {
+   ┆ ┆   
  5 │ ├─▶ }
-   · │       
-   · ╰─────── Prefer rec over undocumented let syntax
+   │ │       
+   │ ╰─────── Prefer rec over undocumented let syntax
 ───╯

--- a/bin/tests/snapshots/manual_inherit__2a92c1cb560d2d727373fb3ad10da2b1_lint.snap
+++ b/bin/tests/snapshots/manual_inherit__2a92c1cb560d2d727373fb3ad10da2b1_lint.snap
@@ -3,10 +3,10 @@ source: bin/tests/manual_inherit.rs
 ---
 let a = 2; in { a = a; }
 ---
-[W03] Warning: Assignment instead of inherit
-   ╭─[<temp_file_path>:1:17]
+[03] Warning: Assignment instead of inherit
+   ╭─[ <temp_file_path>:1:17 ]
    │
  1 │ let a = 2; in { a = a; }
-   ·                 ───┬──  
-   ·                    ╰──── This assignment is better written with inherit
+   │                 ───┬──  
+   │                    ╰──── This assignment is better written with inherit
 ───╯

--- a/bin/tests/snapshots/manual_inherit_from__d185f6bcc057384cb2f1ae3abb567fd1_lint.snap
+++ b/bin/tests/snapshots/manual_inherit_from__d185f6bcc057384cb2f1ae3abb567fd1_lint.snap
@@ -3,10 +3,10 @@ source: bin/tests/manual_inherit_from.rs
 ---
 let a.b = 2; in { b = a.b; }
 ---
-[W04] Warning: Assignment instead of inherit from
-   ╭─[<temp_file_path>:1:19]
+[04] Warning: Assignment instead of inherit from
+   ╭─[ <temp_file_path>:1:19 ]
    │
  1 │ let a.b = 2; in { b = a.b; }
-   ·                   ────┬───  
-   ·                       ╰───── This assignment is better written with inherit
+   │                   ────┬───  
+   │                       ╰───── This assignment is better written with inherit
 ───╯

--- a/bin/tests/snapshots/manual_inherit_from__fddffc3b779f8727d3ce7613925d3d3d_lint.snap
+++ b/bin/tests/snapshots/manual_inherit_from__fddffc3b779f8727d3ce7613925d3d3d_lint.snap
@@ -3,10 +3,10 @@ source: bin/tests/manual_inherit_from.rs
 ---
 let a.b = 2; in { c = a.c; }
 ---
-[W04] Warning: Assignment instead of inherit from
-   ╭─[<temp_file_path>:1:19]
+[04] Warning: Assignment instead of inherit from
+   ╭─[ <temp_file_path>:1:19 ]
    │
  1 │ let a.b = 2; in { c = a.c; }
-   ·                   ────┬───  
-   ·                       ╰───── This assignment is better written with inherit
+   │                   ────┬───  
+   │                       ╰───── This assignment is better written with inherit
 ───╯

--- a/bin/tests/snapshots/redundant_pattern_bind__01ae2aa8e74bbccf70f47469dad2c734_lint.snap
+++ b/bin/tests/snapshots/redundant_pattern_bind__01ae2aa8e74bbccf70f47469dad2c734_lint.snap
@@ -3,10 +3,10 @@ source: bin/tests/redundant_pattern_bind.rs
 ---
 { ... } @ inputs: null
 ---
-[W11] Warning: Found redundant pattern bind in function argument
-   ╭─[<temp_file_path>:1:1]
+[11] Warning: Found redundant pattern bind in function argument
+   ╭─[ <temp_file_path>:1:1 ]
    │
  1 │ { ... } @ inputs: null
-   · ────────┬───────  
-   ·         ╰───────── This pattern bind is redundant, use inputs instead
+   │ ────────┬───────  
+   │         ╰───────── This pattern bind is redundant, use inputs instead
 ───╯

--- a/bin/tests/snapshots/repeated_keys__653aae0c9fb8b448e30e62c7daa38519_lint.snap
+++ b/bin/tests/snapshots/repeated_keys__653aae0c9fb8b448e30e62c7daa38519_lint.snap
@@ -9,16 +9,16 @@ source: bin/tests/repeated_keys.rs
   foo.baz.bar5 = 5;
 }
 ---
-[W20] Warning: Avoid repeated keys in attribute sets
-   ╭─[<temp_file_path>:2:3]
+[20] Warning: Avoid repeated keys in attribute sets
+   ╭─[ <temp_file_path>:2:3 ]
    │
  2 │   foo.baz.bar1 = 1;
-   ·   ──────┬─────  
-   ·         ╰─────── The key foo is first assigned here ...
+   │   ──────┬─────  
+   │         ╰─────── The key foo is first assigned here ...
  3 │   foo.baz.bar2 = 2;
-   ·   ──────┬─────  
-   ·         ╰─────── ... repeated here ...
+   │   ──────┬─────  
+   │         ╰─────── ... repeated here ...
  4 │   foo.baz.bar3 = 3;
-   ·   ──────┬─────  
-   ·         ╰─────── ... and here (2 occurrences omitted). Try foo = { baz.bar1=...; baz.bar2=...; baz.bar3=...; } instead.
+   │   ──────┬─────  
+   │         ╰─────── ... and here (2 occurrences omitted). Try foo = { baz.bar1=...; baz.bar2=...; baz.bar3=...; } instead.
 ───╯

--- a/bin/tests/snapshots/repeated_keys__b1a741b37938f70b92df97e0f3aca480_lint.snap
+++ b/bin/tests/snapshots/repeated_keys__b1a741b37938f70b92df97e0f3aca480_lint.snap
@@ -7,16 +7,16 @@ source: bin/tests/repeated_keys.rs
   foo.again = 1;
 }
 ---
-[W20] Warning: Avoid repeated keys in attribute sets
-   ╭─[<temp_file_path>:2:3]
+[20] Warning: Avoid repeated keys in attribute sets
+   ╭─[ <temp_file_path>:2:3 ]
    │
  2 │   foo.bar = 1;
-   ·   ───┬───  
-   ·      ╰───── The key foo is first assigned here ...
+   │   ───┬───  
+   │      ╰───── The key foo is first assigned here ...
  3 │   foo.baz."hello" = 1;
-   ·   ───────┬───────  
-   ·          ╰───────── ... repeated here ...
+   │   ───────┬───────  
+   │          ╰───────── ... repeated here ...
  4 │   foo.again = 1;
-   ·   ────┬────  
-   ·       ╰────── ... and here. Try foo = { bar=...; baz."hello"=...; again=...; } instead.
+   │   ────┬────  
+   │       ╰────── ... and here. Try foo = { bar=...; baz."hello"=...; again=...; } instead.
 ───╯

--- a/bin/tests/snapshots/unquoted_uri__33baa84c37bca40983a14f7acf371ef0_lint.snap
+++ b/bin/tests/snapshots/unquoted_uri__33baa84c37bca40983a14f7acf371ef0_lint.snap
@@ -3,10 +3,10 @@ source: bin/tests/unquoted_uri.rs
 ---
 github:nerdypepper/statix
 ---
-[W12] Warning: Found unquoted URI expression
-   ╭─[<temp_file_path>:1:1]
+[12] Warning: Found unquoted URI expression
+   ╭─[ <temp_file_path>:1:1 ]
    │
  1 │ github:nerdypepper/statix
-   · ────────────┬────────────  
-   ·             ╰────────────── Consider quoting this URI expression
+   │ ────────────┬────────────  
+   │             ╰────────────── Consider quoting this URI expression
 ───╯

--- a/bin/tests/snapshots/useless_has_attr__3c62cf80cceead28f219a180d924a929_lint.snap
+++ b/bin/tests/snapshots/useless_has_attr__3c62cf80cceead28f219a180d924a929_lint.snap
@@ -3,10 +3,10 @@ source: bin/tests/useless_has_attr.rs
 ---
 if x ? a.b then x.a.b else default
 ---
-[W19] Warning: This `if` expression can be simplified with `or`
-   ╭─[<temp_file_path>:1:1]
+[19] Warning: This `if` expression can be simplified with `or`
+   ╭─[ <temp_file_path>:1:1 ]
    │
  1 │ if x ? a.b then x.a.b else default
-   · ─────────────────┬────────────────  
-   ·                  ╰────────────────── Consider using x.a.b or default instead of this if expression
+   │ ─────────────────┬────────────────  
+   │                  ╰────────────────── Consider using x.a.b or default instead of this if expression
 ───╯

--- a/bin/tests/snapshots/useless_has_attr__514032635e11fe0f21c05881885de045_lint.snap
+++ b/bin/tests/snapshots/useless_has_attr__514032635e11fe0f21c05881885de045_lint.snap
@@ -3,10 +3,10 @@ source: bin/tests/useless_has_attr.rs
 ---
 if x ? a then x.a else default
 ---
-[W19] Warning: This `if` expression can be simplified with `or`
-   ╭─[<temp_file_path>:1:1]
+[19] Warning: This `if` expression can be simplified with `or`
+   ╭─[ <temp_file_path>:1:1 ]
    │
  1 │ if x ? a then x.a else default
-   · ───────────────┬──────────────  
-   ·                ╰──────────────── Consider using x.a or default instead of this if expression
+   │ ───────────────┬──────────────  
+   │                ╰──────────────── Consider using x.a or default instead of this if expression
 ───╯

--- a/bin/tests/snapshots/useless_has_attr__9361572e1b83dd76c88aa8af9b983c7f_lint.snap
+++ b/bin/tests/snapshots/useless_has_attr__9361572e1b83dd76c88aa8af9b983c7f_lint.snap
@@ -3,10 +3,10 @@ source: bin/tests/useless_has_attr.rs
 ---
 if x ? a then x.a else if b then c else d
 ---
-[W19] Warning: This `if` expression can be simplified with `or`
-   ╭─[<temp_file_path>:1:1]
+[19] Warning: This `if` expression can be simplified with `or`
+   ╭─[ <temp_file_path>:1:1 ]
    │
  1 │ if x ? a then x.a else if b then c else d
-   · ────────────────────┬────────────────────  
-   ·                     ╰────────────────────── Consider using x.a or (if b then c else d) instead of this if expression
+   │ ────────────────────┬────────────────────  
+   │                     ╰────────────────────── Consider using x.a or (if b then c else d) instead of this if expression
 ───╯

--- a/bin/tests/snapshots/useless_has_attr__dcdeee74e5d10b5199175881fce69d02_lint.snap
+++ b/bin/tests/snapshots/useless_has_attr__dcdeee74e5d10b5199175881fce69d02_lint.snap
@@ -3,10 +3,10 @@ source: bin/tests/useless_has_attr.rs
 ---
 if x.a ? b then x.a.b else default
 ---
-[W19] Warning: This `if` expression can be simplified with `or`
-   ╭─[<temp_file_path>:1:1]
+[19] Warning: This `if` expression can be simplified with `or`
+   ╭─[ <temp_file_path>:1:1 ]
    │
  1 │ if x.a ? b then x.a.b else default
-   · ─────────────────┬────────────────  
-   ·                  ╰────────────────── Consider using x.a.b or default instead of this if expression
+   │ ─────────────────┬────────────────  
+   │                  ╰────────────────── Consider using x.a.b or default instead of this if expression
 ───╯

--- a/bin/tests/snapshots/useless_has_attr__f5edc729a910faa40ea89cb086561a43_lint.snap
+++ b/bin/tests/snapshots/useless_has_attr__f5edc729a910faa40ea89cb086561a43_lint.snap
@@ -3,10 +3,10 @@ source: bin/tests/useless_has_attr.rs
 ---
 if x ? a then x.a else b.c
 ---
-[W19] Warning: This `if` expression can be simplified with `or`
-   ╭─[<temp_file_path>:1:1]
+[19] Warning: This `if` expression can be simplified with `or`
+   ╭─[ <temp_file_path>:1:1 ]
    │
  1 │ if x ? a then x.a else b.c
-   · ─────────────┬────────────  
-   ·              ╰────────────── Consider using x.a or b.c instead of this if expression
+   │ ─────────────┬────────────  
+   │              ╰────────────── Consider using x.a or b.c instead of this if expression
 ───╯

--- a/bin/tests/snapshots/useless_parens__31ac41c8c6e98946b178fde2f6c5a168_lint.snap
+++ b/bin/tests/snapshots/useless_parens__31ac41c8c6e98946b178fde2f6c5a168_lint.snap
@@ -3,10 +3,10 @@ source: bin/tests/useless_parens.rs
 ---
 ("hello")
 ---
-[W08] Warning: These parentheses can be omitted
-   ╭─[<temp_file_path>:1:1]
+[08] Warning: These parentheses can be omitted
+   ╭─[ <temp_file_path>:1:1 ]
    │
  1 │ ("hello")
-   · ────┬────  
-   ·     ╰────── Useless parentheses around primitive expression
+   │ ────┬────  
+   │     ╰────── Useless parentheses around primitive expression
 ───╯

--- a/bin/tests/snapshots/useless_parens__4d37aa86b470346c97523d0152f7860b_lint.snap
+++ b/bin/tests/snapshots/useless_parens__4d37aa86b470346c97523d0152f7860b_lint.snap
@@ -3,10 +3,10 @@ source: bin/tests/useless_parens.rs
 ---
 let a = (1 + 2); in null
 ---
-[W08] Warning: These parentheses can be omitted
-   ╭─[<temp_file_path>:1:9]
+[08] Warning: These parentheses can be omitted
+   ╭─[ <temp_file_path>:1:9 ]
    │
  1 │ let a = (1 + 2); in null
-   ·         ───┬───  
-   ·            ╰───── Useless parentheses around value in binding
+   │         ───┬───  
+   │            ╰───── Useless parentheses around value in binding
 ───╯

--- a/bin/tests/snapshots/useless_parens__518aa31f8b9a466e2e92490ffd87be42_lint.snap
+++ b/bin/tests/snapshots/useless_parens__518aa31f8b9a466e2e92490ffd87be42_lint.snap
@@ -3,10 +3,10 @@ source: bin/tests/useless_parens.rs
 ---
 let h = ({ inherit (builtins) map; }); in null
 ---
-[W08] Warning: These parentheses can be omitted
-   ╭─[<temp_file_path>:1:9]
+[08] Warning: These parentheses can be omitted
+   ╭─[ <temp_file_path>:1:9 ]
    │
  1 │ let h = ({ inherit (builtins) map; }); in null
-   ·         ──────────────┬──────────────  
-   ·                       ╰──────────────── Useless parentheses around value in binding
+   │         ──────────────┬──────────────  
+   │                       ╰──────────────── Useless parentheses around value in binding
 ───╯

--- a/bin/tests/snapshots/useless_parens__dbf237a5ac629f60efb6cc28b28986f3_lint.snap
+++ b/bin/tests/snapshots/useless_parens__dbf237a5ac629f60efb6cc28b28986f3_lint.snap
@@ -3,10 +3,10 @@ source: bin/tests/useless_parens.rs
 ---
 [(builtins.map)]
 ---
-[W08] Warning: These parentheses can be omitted
-   ╭─[<temp_file_path>:1:2]
+[08] Warning: These parentheses can be omitted
+   ╭─[ <temp_file_path>:1:2 ]
    │
  1 │ [(builtins.map)]
-   ·  ───────┬──────  
-   ·         ╰──────── Useless parentheses around primitive expression
+   │  ───────┬──────  
+   │         ╰──────── Useless parentheses around primitive expression
 ───╯

--- a/bin/tests/snapshots/useless_parens__e77035eacc5250b3a65353c52612eb4a_lint.snap
+++ b/bin/tests/snapshots/useless_parens__e77035eacc5250b3a65353c52612eb4a_lint.snap
@@ -3,10 +3,10 @@ source: bin/tests/useless_parens.rs
 ---
 ({ f = 2; })
 ---
-[W08] Warning: These parentheses can be omitted
-   ╭─[<temp_file_path>:1:1]
+[08] Warning: These parentheses can be omitted
+   ╭─[ <temp_file_path>:1:1 ]
    │
  1 │ ({ f = 2; })
-   · ──────┬─────  
-   ·       ╰─────── Useless parentheses around primitive expression
+   │ ──────┬─────  
+   │       ╰─────── Useless parentheses around primitive expression
 ───╯

--- a/bin/tests/snapshots/useless_parens__ed0b445d7f4db791ac8dcf41de7d3bc4_lint.snap
+++ b/bin/tests/snapshots/useless_parens__ed0b445d7f4db791ac8dcf41de7d3bc4_lint.snap
@@ -3,10 +3,10 @@ source: bin/tests/useless_parens.rs
 ---
 let a = 0; in (null)
 ---
-[W08] Warning: These parentheses can be omitted
-   ╭─[<temp_file_path>:1:15]
+[08] Warning: These parentheses can be omitted
+   ╭─[ <temp_file_path>:1:15 ]
    │
  1 │ let a = 0; in (null)
-   ·               ───┬──  
-   ·                  ╰──── Useless parentheses around body of let expression
+   │               ───┬──  
+   │                  ╰──── Useless parentheses around body of let expression
 ───╯

--- a/bin/tests/snapshots/useless_parens__f04dfa0b3c36c6f2489cba3b913db246_lint.snap
+++ b/bin/tests/snapshots/useless_parens__f04dfa0b3c36c6f2489cba3b913db246_lint.snap
@@ -3,10 +3,10 @@ source: bin/tests/useless_parens.rs
 ---
 let b = 0; in (b)
 ---
-[W08] Warning: These parentheses can be omitted
-   ╭─[<temp_file_path>:1:15]
+[08] Warning: These parentheses can be omitted
+   ╭─[ <temp_file_path>:1:15 ]
    │
  1 │ let b = 0; in (b)
-   ·               ─┬─  
-   ·                ╰─── Useless parentheses around body of let expression
+   │               ─┬─  
+   │                ╰─── Useless parentheses around body of let expression
 ───╯


### PR DESCRIPTION
Fixes https://github.com/oppiliappan/statix/issues/78

When statix receives an empty string via stdin, an empty Report is generated. Passing an empty string to ariadne's Source::from causes an index out of bounds panic. Supplying a string with a single space as a fallback prevents this panic while keeping the error location at byte offset 0.

Output after this fix-

 echo "" | nix run . -- check -s

[E00] Error: Syntax error
   ╭─[<stdin>:1:1]
   │
 1 │
   · │
   · ╰─ Unexpected end of file
───╯