### PR TITLE
fix: Render snapshot `expressions` as readable multi-line Nix code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,7 +274,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -393,14 +393,15 @@ checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
 name = "insta"
-version = "1.43.2"
+version = "1.46.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46fdb647ebde000f43b5b53f773c30cf9b0cb4300453208713fa38b2c70935a0"
+checksum = "e82db8c87c7f1ccecb34ce0c24399b8a73081427f3c7c50a5d597925356115e4"
 dependencies = [
  "console",
  "once_cell",
  "regex",
  "similar",
+ "tempfile",
 ]
 
 [[package]]
@@ -621,7 +622,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -766,7 +767,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,7 +274,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -393,15 +393,14 @@ checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
 name = "insta"
-version = "1.46.3"
+version = "1.43.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e82db8c87c7f1ccecb34ce0c24399b8a73081427f3c7c50a5d597925356115e4"
+checksum = "46fdb647ebde000f43b5b53f773c30cf9b0cb4300453208713fa38b2c70935a0"
 dependencies = [
  "console",
  "once_cell",
  "regex",
  "similar",
- "tempfile",
 ]
 
 [[package]]
@@ -622,7 +621,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -767,7 +766,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ hex = "*"
 ignore = "*"
 indexmap = "*"
 indoc = "*"
-insta = { features = ["filters"], version = "*" }
+insta = { features = ["filters"], version = "1.46.3" }
 lazy_static = "*"
 lib.path = "./lib"
 macros.path = "./macros"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ hex = "*"
 ignore = "*"
 indexmap = "*"
 indoc = "*"
-insta = { features = ["filters"], version = "1.46.3" }
+insta = { features = ["filters"], version = "*" }
 lazy_static = "*"
 lib.path = "./lib"
 macros.path = "./macros"

--- a/bin/tests/snapshots/bool_comparison__fix_01765d342111cdd7f2f68ac70b4a9451e5380adb64ed4d60c851c6ab437bc0ed.snap
+++ b/bin/tests/snapshots/bool_comparison__fix_01765d342111cdd7f2f68ac70b4a9451e5380adb64ed4d60c851c6ab437bc0ed.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_comparison.rs
-expression: snapshot
 ---
 expression:
 true != false

--- a/bin/tests/snapshots/bool_comparison__fix_01765d342111cdd7f2f68ac70b4a9451e5380adb64ed4d60c851c6ab437bc0ed.snap
+++ b/bin/tests/snapshots/bool_comparison__fix_01765d342111cdd7f2f68ac70b4a9451e5380adb64ed4d60c851c6ab437bc0ed.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_comparison.rs
 ---
-expression:
 true != false
 ---

--- a/bin/tests/snapshots/bool_comparison__fix_01765d342111cdd7f2f68ac70b4a9451e5380adb64ed4d60c851c6ab437bc0ed.snap
+++ b/bin/tests/snapshots/bool_comparison__fix_01765d342111cdd7f2f68ac70b4a9451e5380adb64ed4d60c851c6ab437bc0ed.snap
@@ -1,5 +1,7 @@
 ---
 source: bin/tests/bool_comparison.rs
-expression: "\"true != false\""
+expression: snapshot
 ---
-
+expression:
+true != false
+---

--- a/bin/tests/snapshots/bool_comparison__fix_3fce60992c69dd4f86be49b4f2898f9ecd8fce2117de78ba9dee164f01ff445b.snap
+++ b/bin/tests/snapshots/bool_comparison__fix_3fce60992c69dd4f86be49b4f2898f9ecd8fce2117de78ba9dee164f01ff445b.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_comparison.rs
-expression: snapshot
 ---
 expression:
 false != true

--- a/bin/tests/snapshots/bool_comparison__fix_3fce60992c69dd4f86be49b4f2898f9ecd8fce2117de78ba9dee164f01ff445b.snap
+++ b/bin/tests/snapshots/bool_comparison__fix_3fce60992c69dd4f86be49b4f2898f9ecd8fce2117de78ba9dee164f01ff445b.snap
@@ -1,5 +1,7 @@
 ---
 source: bin/tests/bool_comparison.rs
-expression: "\"false != true\""
+expression: snapshot
 ---
-
+expression:
+false != true
+---

--- a/bin/tests/snapshots/bool_comparison__fix_3fce60992c69dd4f86be49b4f2898f9ecd8fce2117de78ba9dee164f01ff445b.snap
+++ b/bin/tests/snapshots/bool_comparison__fix_3fce60992c69dd4f86be49b4f2898f9ecd8fce2117de78ba9dee164f01ff445b.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_comparison.rs
 ---
-expression:
 false != true
 ---

--- a/bin/tests/snapshots/bool_comparison__fix_43a857afe823ef70b47d4e0fbf00af8951e09a9a9891d29b3ba9e762a2978adb.snap
+++ b/bin/tests/snapshots/bool_comparison__fix_43a857afe823ef70b47d4e0fbf00af8951e09a9a9891d29b3ba9e762a2978adb.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_comparison.rs
 ---
-expression:
 true == d
 ---

--- a/bin/tests/snapshots/bool_comparison__fix_43a857afe823ef70b47d4e0fbf00af8951e09a9a9891d29b3ba9e762a2978adb.snap
+++ b/bin/tests/snapshots/bool_comparison__fix_43a857afe823ef70b47d4e0fbf00af8951e09a9a9891d29b3ba9e762a2978adb.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_comparison.rs
-expression: snapshot
 ---
 expression:
 true == d

--- a/bin/tests/snapshots/bool_comparison__fix_43a857afe823ef70b47d4e0fbf00af8951e09a9a9891d29b3ba9e762a2978adb.snap
+++ b/bin/tests/snapshots/bool_comparison__fix_43a857afe823ef70b47d4e0fbf00af8951e09a9a9891d29b3ba9e762a2978adb.snap
@@ -1,5 +1,7 @@
 ---
 source: bin/tests/bool_comparison.rs
-expression: "\"true == d\""
+expression: snapshot
 ---
-
+expression:
+true == d
+---

--- a/bin/tests/snapshots/bool_comparison__fix_4e4d41c24c973c0bc560aeaaf95c464f576f6a4446acc939f98ebb9329d6b700.snap
+++ b/bin/tests/snapshots/bool_comparison__fix_4e4d41c24c973c0bc560aeaaf95c464f576f6a4446acc939f98ebb9329d6b700.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_comparison.rs
-expression: snapshot
 ---
 expression:
 k != l

--- a/bin/tests/snapshots/bool_comparison__fix_4e4d41c24c973c0bc560aeaaf95c464f576f6a4446acc939f98ebb9329d6b700.snap
+++ b/bin/tests/snapshots/bool_comparison__fix_4e4d41c24c973c0bc560aeaaf95c464f576f6a4446acc939f98ebb9329d6b700.snap
@@ -1,5 +1,7 @@
 ---
 source: bin/tests/bool_comparison.rs
-expression: "\"k != l\""
+expression: snapshot
 ---
-
+expression:
+k != l
+---

--- a/bin/tests/snapshots/bool_comparison__fix_4e4d41c24c973c0bc560aeaaf95c464f576f6a4446acc939f98ebb9329d6b700.snap
+++ b/bin/tests/snapshots/bool_comparison__fix_4e4d41c24c973c0bc560aeaaf95c464f576f6a4446acc939f98ebb9329d6b700.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_comparison.rs
 ---
-expression:
 k != l
 ---

--- a/bin/tests/snapshots/bool_comparison__fix_55dfc255fdce66acbcebd803bdc0a33666717f07ceb798a97e29b4fdf1505560.snap
+++ b/bin/tests/snapshots/bool_comparison__fix_55dfc255fdce66acbcebd803bdc0a33666717f07ceb798a97e29b4fdf1505560.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_comparison.rs
 ---
-expression:
 a == false
 ---

--- a/bin/tests/snapshots/bool_comparison__fix_55dfc255fdce66acbcebd803bdc0a33666717f07ceb798a97e29b4fdf1505560.snap
+++ b/bin/tests/snapshots/bool_comparison__fix_55dfc255fdce66acbcebd803bdc0a33666717f07ceb798a97e29b4fdf1505560.snap
@@ -1,5 +1,7 @@
 ---
 source: bin/tests/bool_comparison.rs
-expression: "\"a == false\""
+expression: snapshot
 ---
-
+expression:
+a == false
+---

--- a/bin/tests/snapshots/bool_comparison__fix_55dfc255fdce66acbcebd803bdc0a33666717f07ceb798a97e29b4fdf1505560.snap
+++ b/bin/tests/snapshots/bool_comparison__fix_55dfc255fdce66acbcebd803bdc0a33666717f07ceb798a97e29b4fdf1505560.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_comparison.rs
-expression: snapshot
 ---
 expression:
 a == false

--- a/bin/tests/snapshots/bool_comparison__fix_5d2c71eef69cc07e519dc3646f786ba7a32f5546c3a2194d2636a2684391e3f1.snap
+++ b/bin/tests/snapshots/bool_comparison__fix_5d2c71eef69cc07e519dc3646f786ba7a32f5546c3a2194d2636a2684391e3f1.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_comparison.rs
 ---
-expression:
 false == false
 ---

--- a/bin/tests/snapshots/bool_comparison__fix_5d2c71eef69cc07e519dc3646f786ba7a32f5546c3a2194d2636a2684391e3f1.snap
+++ b/bin/tests/snapshots/bool_comparison__fix_5d2c71eef69cc07e519dc3646f786ba7a32f5546c3a2194d2636a2684391e3f1.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_comparison.rs
-expression: snapshot
 ---
 expression:
 false == false

--- a/bin/tests/snapshots/bool_comparison__fix_5d2c71eef69cc07e519dc3646f786ba7a32f5546c3a2194d2636a2684391e3f1.snap
+++ b/bin/tests/snapshots/bool_comparison__fix_5d2c71eef69cc07e519dc3646f786ba7a32f5546c3a2194d2636a2684391e3f1.snap
@@ -1,5 +1,7 @@
 ---
 source: bin/tests/bool_comparison.rs
-expression: "\"false == false\""
+expression: snapshot
 ---
-
+expression:
+false == false
+---

--- a/bin/tests/snapshots/bool_comparison__fix_82b623ef0ecd1e0e70c1dbe39f02832657a82dd5a58392f23345b22467a89b1a.snap
+++ b/bin/tests/snapshots/bool_comparison__fix_82b623ef0ecd1e0e70c1dbe39f02832657a82dd5a58392f23345b22467a89b1a.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_comparison.rs
-expression: snapshot
 ---
 expression:
 true == true

--- a/bin/tests/snapshots/bool_comparison__fix_82b623ef0ecd1e0e70c1dbe39f02832657a82dd5a58392f23345b22467a89b1a.snap
+++ b/bin/tests/snapshots/bool_comparison__fix_82b623ef0ecd1e0e70c1dbe39f02832657a82dd5a58392f23345b22467a89b1a.snap
@@ -1,5 +1,7 @@
 ---
 source: bin/tests/bool_comparison.rs
-expression: "\"true == true\""
+expression: snapshot
 ---
-
+expression:
+true == true
+---

--- a/bin/tests/snapshots/bool_comparison__fix_82b623ef0ecd1e0e70c1dbe39f02832657a82dd5a58392f23345b22467a89b1a.snap
+++ b/bin/tests/snapshots/bool_comparison__fix_82b623ef0ecd1e0e70c1dbe39f02832657a82dd5a58392f23345b22467a89b1a.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_comparison.rs
 ---
-expression:
 true == true
 ---

--- a/bin/tests/snapshots/bool_comparison__fix_852249844e4f5e03707d323181ca8645f39f390d9a91490dd6926c3df73f1912.snap
+++ b/bin/tests/snapshots/bool_comparison__fix_852249844e4f5e03707d323181ca8645f39f390d9a91490dd6926c3df73f1912.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_comparison.rs
-expression: snapshot
 ---
 expression:
 true != true

--- a/bin/tests/snapshots/bool_comparison__fix_852249844e4f5e03707d323181ca8645f39f390d9a91490dd6926c3df73f1912.snap
+++ b/bin/tests/snapshots/bool_comparison__fix_852249844e4f5e03707d323181ca8645f39f390d9a91490dd6926c3df73f1912.snap
@@ -1,5 +1,7 @@
 ---
 source: bin/tests/bool_comparison.rs
-expression: "\"true != true\""
+expression: snapshot
 ---
-
+expression:
+true != true
+---

--- a/bin/tests/snapshots/bool_comparison__fix_852249844e4f5e03707d323181ca8645f39f390d9a91490dd6926c3df73f1912.snap
+++ b/bin/tests/snapshots/bool_comparison__fix_852249844e4f5e03707d323181ca8645f39f390d9a91490dd6926c3df73f1912.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_comparison.rs
 ---
-expression:
 true != true
 ---

--- a/bin/tests/snapshots/bool_comparison__fix_953514e1d8b3ed9ecc2a23a82ab52f3b71eb218061d8a678afbbdb09b717cd0f.snap
+++ b/bin/tests/snapshots/bool_comparison__fix_953514e1d8b3ed9ecc2a23a82ab52f3b71eb218061d8a678afbbdb09b717cd0f.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_comparison.rs
-expression: snapshot
 ---
 expression:
 false != c

--- a/bin/tests/snapshots/bool_comparison__fix_953514e1d8b3ed9ecc2a23a82ab52f3b71eb218061d8a678afbbdb09b717cd0f.snap
+++ b/bin/tests/snapshots/bool_comparison__fix_953514e1d8b3ed9ecc2a23a82ab52f3b71eb218061d8a678afbbdb09b717cd0f.snap
@@ -1,5 +1,7 @@
 ---
 source: bin/tests/bool_comparison.rs
-expression: "\"false != c\""
+expression: snapshot
 ---
-
+expression:
+false != c
+---

--- a/bin/tests/snapshots/bool_comparison__fix_953514e1d8b3ed9ecc2a23a82ab52f3b71eb218061d8a678afbbdb09b717cd0f.snap
+++ b/bin/tests/snapshots/bool_comparison__fix_953514e1d8b3ed9ecc2a23a82ab52f3b71eb218061d8a678afbbdb09b717cd0f.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_comparison.rs
 ---
-expression:
 false != c
 ---

--- a/bin/tests/snapshots/bool_comparison__fix_a11a365119d2c64750d4253426c99db3e016d21e6183a706845dfed17d803393.snap
+++ b/bin/tests/snapshots/bool_comparison__fix_a11a365119d2c64750d4253426c99db3e016d21e6183a706845dfed17d803393.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_comparison.rs
 ---
-expression:
 b == true
 ---

--- a/bin/tests/snapshots/bool_comparison__fix_a11a365119d2c64750d4253426c99db3e016d21e6183a706845dfed17d803393.snap
+++ b/bin/tests/snapshots/bool_comparison__fix_a11a365119d2c64750d4253426c99db3e016d21e6183a706845dfed17d803393.snap
@@ -1,5 +1,7 @@
 ---
 source: bin/tests/bool_comparison.rs
-expression: "\"b == true\""
+expression: snapshot
 ---
-
+expression:
+b == true
+---

--- a/bin/tests/snapshots/bool_comparison__fix_a11a365119d2c64750d4253426c99db3e016d21e6183a706845dfed17d803393.snap
+++ b/bin/tests/snapshots/bool_comparison__fix_a11a365119d2c64750d4253426c99db3e016d21e6183a706845dfed17d803393.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_comparison.rs
-expression: snapshot
 ---
 expression:
 b == true

--- a/bin/tests/snapshots/bool_comparison__fix_b3f4aa5bde6c87b7b513da28d18f9612a7d67a527e818e7b599d193265345cc6.snap
+++ b/bin/tests/snapshots/bool_comparison__fix_b3f4aa5bde6c87b7b513da28d18f9612a7d67a527e818e7b599d193265345cc6.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_comparison.rs
 ---
-expression:
 i == j
 ---

--- a/bin/tests/snapshots/bool_comparison__fix_b3f4aa5bde6c87b7b513da28d18f9612a7d67a527e818e7b599d193265345cc6.snap
+++ b/bin/tests/snapshots/bool_comparison__fix_b3f4aa5bde6c87b7b513da28d18f9612a7d67a527e818e7b599d193265345cc6.snap
@@ -1,5 +1,7 @@
 ---
 source: bin/tests/bool_comparison.rs
-expression: "\"i == j\""
+expression: snapshot
 ---
-
+expression:
+i == j
+---

--- a/bin/tests/snapshots/bool_comparison__fix_b3f4aa5bde6c87b7b513da28d18f9612a7d67a527e818e7b599d193265345cc6.snap
+++ b/bin/tests/snapshots/bool_comparison__fix_b3f4aa5bde6c87b7b513da28d18f9612a7d67a527e818e7b599d193265345cc6.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_comparison.rs
-expression: snapshot
 ---
 expression:
 i == j

--- a/bin/tests/snapshots/bool_comparison__fix_ba56854c55bd3954b56d4e0c3d32b65cd144d55b060637c5ff8085d81bef6c49.snap
+++ b/bin/tests/snapshots/bool_comparison__fix_ba56854c55bd3954b56d4e0c3d32b65cd144d55b060637c5ff8085d81bef6c49.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_comparison.rs
 ---
-expression:
 false == true
 ---

--- a/bin/tests/snapshots/bool_comparison__fix_ba56854c55bd3954b56d4e0c3d32b65cd144d55b060637c5ff8085d81bef6c49.snap
+++ b/bin/tests/snapshots/bool_comparison__fix_ba56854c55bd3954b56d4e0c3d32b65cd144d55b060637c5ff8085d81bef6c49.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_comparison.rs
-expression: snapshot
 ---
 expression:
 false == true

--- a/bin/tests/snapshots/bool_comparison__fix_ba56854c55bd3954b56d4e0c3d32b65cd144d55b060637c5ff8085d81bef6c49.snap
+++ b/bin/tests/snapshots/bool_comparison__fix_ba56854c55bd3954b56d4e0c3d32b65cd144d55b060637c5ff8085d81bef6c49.snap
@@ -1,5 +1,7 @@
 ---
 source: bin/tests/bool_comparison.rs
-expression: "\"false == true\""
+expression: snapshot
 ---
-
+expression:
+false == true
+---

--- a/bin/tests/snapshots/bool_comparison__fix_e242c6e0c4298e00ab2cae2f89de63cc77e833cf6ad2c8eb1047a38df7f25564.snap
+++ b/bin/tests/snapshots/bool_comparison__fix_e242c6e0c4298e00ab2cae2f89de63cc77e833cf6ad2c8eb1047a38df7f25564.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_comparison.rs
 ---
-expression:
 false != false
 ---

--- a/bin/tests/snapshots/bool_comparison__fix_e242c6e0c4298e00ab2cae2f89de63cc77e833cf6ad2c8eb1047a38df7f25564.snap
+++ b/bin/tests/snapshots/bool_comparison__fix_e242c6e0c4298e00ab2cae2f89de63cc77e833cf6ad2c8eb1047a38df7f25564.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_comparison.rs
-expression: snapshot
 ---
 expression:
 false != false

--- a/bin/tests/snapshots/bool_comparison__fix_e242c6e0c4298e00ab2cae2f89de63cc77e833cf6ad2c8eb1047a38df7f25564.snap
+++ b/bin/tests/snapshots/bool_comparison__fix_e242c6e0c4298e00ab2cae2f89de63cc77e833cf6ad2c8eb1047a38df7f25564.snap
@@ -1,5 +1,7 @@
 ---
 source: bin/tests/bool_comparison.rs
-expression: "\"false != false\""
+expression: snapshot
 ---
-
+expression:
+false != false
+---

--- a/bin/tests/snapshots/bool_comparison__fix_eb450df0fb6d76e9df94f175a6b87a7c1a667495e18432ed8f38540fd051cec1.snap
+++ b/bin/tests/snapshots/bool_comparison__fix_eb450df0fb6d76e9df94f175a6b87a7c1a667495e18432ed8f38540fd051cec1.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_comparison.rs
 ---
-expression:
 true == false
 ---

--- a/bin/tests/snapshots/bool_comparison__fix_eb450df0fb6d76e9df94f175a6b87a7c1a667495e18432ed8f38540fd051cec1.snap
+++ b/bin/tests/snapshots/bool_comparison__fix_eb450df0fb6d76e9df94f175a6b87a7c1a667495e18432ed8f38540fd051cec1.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_comparison.rs
-expression: snapshot
 ---
 expression:
 true == false

--- a/bin/tests/snapshots/bool_comparison__fix_eb450df0fb6d76e9df94f175a6b87a7c1a667495e18432ed8f38540fd051cec1.snap
+++ b/bin/tests/snapshots/bool_comparison__fix_eb450df0fb6d76e9df94f175a6b87a7c1a667495e18432ed8f38540fd051cec1.snap
@@ -1,5 +1,7 @@
 ---
 source: bin/tests/bool_comparison.rs
-expression: "\"true == false\""
+expression: snapshot
 ---
-
+expression:
+true == false
+---

--- a/bin/tests/snapshots/bool_comparison__lint_01765d342111cdd7f2f68ac70b4a9451e5380adb64ed4d60c851c6ab437bc0ed.snap
+++ b/bin/tests/snapshots/bool_comparison__lint_01765d342111cdd7f2f68ac70b4a9451e5380adb64ed4d60c851c6ab437bc0ed.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/bool_comparison.rs
 ---
-expression:
 true != false
 ---
 [W01] Warning: Equality comparison between boolean literals

--- a/bin/tests/snapshots/bool_comparison__lint_01765d342111cdd7f2f68ac70b4a9451e5380adb64ed4d60c851c6ab437bc0ed.snap
+++ b/bin/tests/snapshots/bool_comparison__lint_01765d342111cdd7f2f68ac70b4a9451e5380adb64ed4d60c851c6ab437bc0ed.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/bool_comparison.rs
-expression: "\"true != false\""
+expression: snapshot
+---
+expression:
+true != false
 ---
 [W01] Warning: Equality comparison between boolean literals
    ╭─[<temp_file_path>:1:1]

--- a/bin/tests/snapshots/bool_comparison__lint_01765d342111cdd7f2f68ac70b4a9451e5380adb64ed4d60c851c6ab437bc0ed.snap
+++ b/bin/tests/snapshots/bool_comparison__lint_01765d342111cdd7f2f68ac70b4a9451e5380adb64ed4d60c851c6ab437bc0ed.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_comparison.rs
-expression: snapshot
 ---
 expression:
 true != false

--- a/bin/tests/snapshots/bool_comparison__lint_3fce60992c69dd4f86be49b4f2898f9ecd8fce2117de78ba9dee164f01ff445b.snap
+++ b/bin/tests/snapshots/bool_comparison__lint_3fce60992c69dd4f86be49b4f2898f9ecd8fce2117de78ba9dee164f01ff445b.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_comparison.rs
-expression: snapshot
 ---
 expression:
 false != true

--- a/bin/tests/snapshots/bool_comparison__lint_3fce60992c69dd4f86be49b4f2898f9ecd8fce2117de78ba9dee164f01ff445b.snap
+++ b/bin/tests/snapshots/bool_comparison__lint_3fce60992c69dd4f86be49b4f2898f9ecd8fce2117de78ba9dee164f01ff445b.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/bool_comparison.rs
-expression: "\"false != true\""
+expression: snapshot
+---
+expression:
+false != true
 ---
 [W01] Warning: Equality comparison between boolean literals
    ╭─[<temp_file_path>:1:1]

--- a/bin/tests/snapshots/bool_comparison__lint_3fce60992c69dd4f86be49b4f2898f9ecd8fce2117de78ba9dee164f01ff445b.snap
+++ b/bin/tests/snapshots/bool_comparison__lint_3fce60992c69dd4f86be49b4f2898f9ecd8fce2117de78ba9dee164f01ff445b.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/bool_comparison.rs
 ---
-expression:
 false != true
 ---
 [W01] Warning: Equality comparison between boolean literals

--- a/bin/tests/snapshots/bool_comparison__lint_43a857afe823ef70b47d4e0fbf00af8951e09a9a9891d29b3ba9e762a2978adb.snap
+++ b/bin/tests/snapshots/bool_comparison__lint_43a857afe823ef70b47d4e0fbf00af8951e09a9a9891d29b3ba9e762a2978adb.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_comparison.rs
 ---
-expression:
 true == d
 ---

--- a/bin/tests/snapshots/bool_comparison__lint_43a857afe823ef70b47d4e0fbf00af8951e09a9a9891d29b3ba9e762a2978adb.snap
+++ b/bin/tests/snapshots/bool_comparison__lint_43a857afe823ef70b47d4e0fbf00af8951e09a9a9891d29b3ba9e762a2978adb.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_comparison.rs
-expression: snapshot
 ---
 expression:
 true == d

--- a/bin/tests/snapshots/bool_comparison__lint_43a857afe823ef70b47d4e0fbf00af8951e09a9a9891d29b3ba9e762a2978adb.snap
+++ b/bin/tests/snapshots/bool_comparison__lint_43a857afe823ef70b47d4e0fbf00af8951e09a9a9891d29b3ba9e762a2978adb.snap
@@ -1,5 +1,7 @@
 ---
 source: bin/tests/bool_comparison.rs
-expression: "\"true == d\""
+expression: snapshot
 ---
-
+expression:
+true == d
+---

--- a/bin/tests/snapshots/bool_comparison__lint_4e4d41c24c973c0bc560aeaaf95c464f576f6a4446acc939f98ebb9329d6b700.snap
+++ b/bin/tests/snapshots/bool_comparison__lint_4e4d41c24c973c0bc560aeaaf95c464f576f6a4446acc939f98ebb9329d6b700.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_comparison.rs
-expression: snapshot
 ---
 expression:
 k != l

--- a/bin/tests/snapshots/bool_comparison__lint_4e4d41c24c973c0bc560aeaaf95c464f576f6a4446acc939f98ebb9329d6b700.snap
+++ b/bin/tests/snapshots/bool_comparison__lint_4e4d41c24c973c0bc560aeaaf95c464f576f6a4446acc939f98ebb9329d6b700.snap
@@ -1,5 +1,7 @@
 ---
 source: bin/tests/bool_comparison.rs
-expression: "\"k != l\""
+expression: snapshot
 ---
-
+expression:
+k != l
+---

--- a/bin/tests/snapshots/bool_comparison__lint_4e4d41c24c973c0bc560aeaaf95c464f576f6a4446acc939f98ebb9329d6b700.snap
+++ b/bin/tests/snapshots/bool_comparison__lint_4e4d41c24c973c0bc560aeaaf95c464f576f6a4446acc939f98ebb9329d6b700.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_comparison.rs
 ---
-expression:
 k != l
 ---

--- a/bin/tests/snapshots/bool_comparison__lint_55dfc255fdce66acbcebd803bdc0a33666717f07ceb798a97e29b4fdf1505560.snap
+++ b/bin/tests/snapshots/bool_comparison__lint_55dfc255fdce66acbcebd803bdc0a33666717f07ceb798a97e29b4fdf1505560.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_comparison.rs
 ---
-expression:
 a == false
 ---

--- a/bin/tests/snapshots/bool_comparison__lint_55dfc255fdce66acbcebd803bdc0a33666717f07ceb798a97e29b4fdf1505560.snap
+++ b/bin/tests/snapshots/bool_comparison__lint_55dfc255fdce66acbcebd803bdc0a33666717f07ceb798a97e29b4fdf1505560.snap
@@ -1,5 +1,7 @@
 ---
 source: bin/tests/bool_comparison.rs
-expression: "\"a == false\""
+expression: snapshot
 ---
-
+expression:
+a == false
+---

--- a/bin/tests/snapshots/bool_comparison__lint_55dfc255fdce66acbcebd803bdc0a33666717f07ceb798a97e29b4fdf1505560.snap
+++ b/bin/tests/snapshots/bool_comparison__lint_55dfc255fdce66acbcebd803bdc0a33666717f07ceb798a97e29b4fdf1505560.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_comparison.rs
-expression: snapshot
 ---
 expression:
 a == false

--- a/bin/tests/snapshots/bool_comparison__lint_5d2c71eef69cc07e519dc3646f786ba7a32f5546c3a2194d2636a2684391e3f1.snap
+++ b/bin/tests/snapshots/bool_comparison__lint_5d2c71eef69cc07e519dc3646f786ba7a32f5546c3a2194d2636a2684391e3f1.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_comparison.rs
-expression: snapshot
 ---
 expression:
 false == false

--- a/bin/tests/snapshots/bool_comparison__lint_5d2c71eef69cc07e519dc3646f786ba7a32f5546c3a2194d2636a2684391e3f1.snap
+++ b/bin/tests/snapshots/bool_comparison__lint_5d2c71eef69cc07e519dc3646f786ba7a32f5546c3a2194d2636a2684391e3f1.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/bool_comparison.rs
 ---
-expression:
 false == false
 ---
 [W01] Warning: Equality comparison between boolean literals

--- a/bin/tests/snapshots/bool_comparison__lint_5d2c71eef69cc07e519dc3646f786ba7a32f5546c3a2194d2636a2684391e3f1.snap
+++ b/bin/tests/snapshots/bool_comparison__lint_5d2c71eef69cc07e519dc3646f786ba7a32f5546c3a2194d2636a2684391e3f1.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/bool_comparison.rs
-expression: "\"false == false\""
+expression: snapshot
+---
+expression:
+false == false
 ---
 [W01] Warning: Equality comparison between boolean literals
    ╭─[<temp_file_path>:1:1]

--- a/bin/tests/snapshots/bool_comparison__lint_82b623ef0ecd1e0e70c1dbe39f02832657a82dd5a58392f23345b22467a89b1a.snap
+++ b/bin/tests/snapshots/bool_comparison__lint_82b623ef0ecd1e0e70c1dbe39f02832657a82dd5a58392f23345b22467a89b1a.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_comparison.rs
-expression: snapshot
 ---
 expression:
 true == true

--- a/bin/tests/snapshots/bool_comparison__lint_82b623ef0ecd1e0e70c1dbe39f02832657a82dd5a58392f23345b22467a89b1a.snap
+++ b/bin/tests/snapshots/bool_comparison__lint_82b623ef0ecd1e0e70c1dbe39f02832657a82dd5a58392f23345b22467a89b1a.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/bool_comparison.rs
-expression: "\"true == true\""
+expression: snapshot
+---
+expression:
+true == true
 ---
 [W01] Warning: Equality comparison between boolean literals
    ╭─[<temp_file_path>:1:1]

--- a/bin/tests/snapshots/bool_comparison__lint_82b623ef0ecd1e0e70c1dbe39f02832657a82dd5a58392f23345b22467a89b1a.snap
+++ b/bin/tests/snapshots/bool_comparison__lint_82b623ef0ecd1e0e70c1dbe39f02832657a82dd5a58392f23345b22467a89b1a.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/bool_comparison.rs
 ---
-expression:
 true == true
 ---
 [W01] Warning: Equality comparison between boolean literals

--- a/bin/tests/snapshots/bool_comparison__lint_852249844e4f5e03707d323181ca8645f39f390d9a91490dd6926c3df73f1912.snap
+++ b/bin/tests/snapshots/bool_comparison__lint_852249844e4f5e03707d323181ca8645f39f390d9a91490dd6926c3df73f1912.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/bool_comparison.rs
 ---
-expression:
 true != true
 ---
 [W01] Warning: Equality comparison between boolean literals

--- a/bin/tests/snapshots/bool_comparison__lint_852249844e4f5e03707d323181ca8645f39f390d9a91490dd6926c3df73f1912.snap
+++ b/bin/tests/snapshots/bool_comparison__lint_852249844e4f5e03707d323181ca8645f39f390d9a91490dd6926c3df73f1912.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_comparison.rs
-expression: snapshot
 ---
 expression:
 true != true

--- a/bin/tests/snapshots/bool_comparison__lint_852249844e4f5e03707d323181ca8645f39f390d9a91490dd6926c3df73f1912.snap
+++ b/bin/tests/snapshots/bool_comparison__lint_852249844e4f5e03707d323181ca8645f39f390d9a91490dd6926c3df73f1912.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/bool_comparison.rs
-expression: "\"true != true\""
+expression: snapshot
+---
+expression:
+true != true
 ---
 [W01] Warning: Equality comparison between boolean literals
    ╭─[<temp_file_path>:1:1]

--- a/bin/tests/snapshots/bool_comparison__lint_953514e1d8b3ed9ecc2a23a82ab52f3b71eb218061d8a678afbbdb09b717cd0f.snap
+++ b/bin/tests/snapshots/bool_comparison__lint_953514e1d8b3ed9ecc2a23a82ab52f3b71eb218061d8a678afbbdb09b717cd0f.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_comparison.rs
-expression: snapshot
 ---
 expression:
 false != c

--- a/bin/tests/snapshots/bool_comparison__lint_953514e1d8b3ed9ecc2a23a82ab52f3b71eb218061d8a678afbbdb09b717cd0f.snap
+++ b/bin/tests/snapshots/bool_comparison__lint_953514e1d8b3ed9ecc2a23a82ab52f3b71eb218061d8a678afbbdb09b717cd0f.snap
@@ -1,5 +1,7 @@
 ---
 source: bin/tests/bool_comparison.rs
-expression: "\"false != c\""
+expression: snapshot
 ---
-
+expression:
+false != c
+---

--- a/bin/tests/snapshots/bool_comparison__lint_953514e1d8b3ed9ecc2a23a82ab52f3b71eb218061d8a678afbbdb09b717cd0f.snap
+++ b/bin/tests/snapshots/bool_comparison__lint_953514e1d8b3ed9ecc2a23a82ab52f3b71eb218061d8a678afbbdb09b717cd0f.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_comparison.rs
 ---
-expression:
 false != c
 ---

--- a/bin/tests/snapshots/bool_comparison__lint_a11a365119d2c64750d4253426c99db3e016d21e6183a706845dfed17d803393.snap
+++ b/bin/tests/snapshots/bool_comparison__lint_a11a365119d2c64750d4253426c99db3e016d21e6183a706845dfed17d803393.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_comparison.rs
 ---
-expression:
 b == true
 ---

--- a/bin/tests/snapshots/bool_comparison__lint_a11a365119d2c64750d4253426c99db3e016d21e6183a706845dfed17d803393.snap
+++ b/bin/tests/snapshots/bool_comparison__lint_a11a365119d2c64750d4253426c99db3e016d21e6183a706845dfed17d803393.snap
@@ -1,5 +1,7 @@
 ---
 source: bin/tests/bool_comparison.rs
-expression: "\"b == true\""
+expression: snapshot
 ---
-
+expression:
+b == true
+---

--- a/bin/tests/snapshots/bool_comparison__lint_a11a365119d2c64750d4253426c99db3e016d21e6183a706845dfed17d803393.snap
+++ b/bin/tests/snapshots/bool_comparison__lint_a11a365119d2c64750d4253426c99db3e016d21e6183a706845dfed17d803393.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_comparison.rs
-expression: snapshot
 ---
 expression:
 b == true

--- a/bin/tests/snapshots/bool_comparison__lint_b3f4aa5bde6c87b7b513da28d18f9612a7d67a527e818e7b599d193265345cc6.snap
+++ b/bin/tests/snapshots/bool_comparison__lint_b3f4aa5bde6c87b7b513da28d18f9612a7d67a527e818e7b599d193265345cc6.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_comparison.rs
 ---
-expression:
 i == j
 ---

--- a/bin/tests/snapshots/bool_comparison__lint_b3f4aa5bde6c87b7b513da28d18f9612a7d67a527e818e7b599d193265345cc6.snap
+++ b/bin/tests/snapshots/bool_comparison__lint_b3f4aa5bde6c87b7b513da28d18f9612a7d67a527e818e7b599d193265345cc6.snap
@@ -1,5 +1,7 @@
 ---
 source: bin/tests/bool_comparison.rs
-expression: "\"i == j\""
+expression: snapshot
 ---
-
+expression:
+i == j
+---

--- a/bin/tests/snapshots/bool_comparison__lint_b3f4aa5bde6c87b7b513da28d18f9612a7d67a527e818e7b599d193265345cc6.snap
+++ b/bin/tests/snapshots/bool_comparison__lint_b3f4aa5bde6c87b7b513da28d18f9612a7d67a527e818e7b599d193265345cc6.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_comparison.rs
-expression: snapshot
 ---
 expression:
 i == j

--- a/bin/tests/snapshots/bool_comparison__lint_ba56854c55bd3954b56d4e0c3d32b65cd144d55b060637c5ff8085d81bef6c49.snap
+++ b/bin/tests/snapshots/bool_comparison__lint_ba56854c55bd3954b56d4e0c3d32b65cd144d55b060637c5ff8085d81bef6c49.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/bool_comparison.rs
 ---
-expression:
 false == true
 ---
 [W01] Warning: Equality comparison between boolean literals

--- a/bin/tests/snapshots/bool_comparison__lint_ba56854c55bd3954b56d4e0c3d32b65cd144d55b060637c5ff8085d81bef6c49.snap
+++ b/bin/tests/snapshots/bool_comparison__lint_ba56854c55bd3954b56d4e0c3d32b65cd144d55b060637c5ff8085d81bef6c49.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_comparison.rs
-expression: snapshot
 ---
 expression:
 false == true

--- a/bin/tests/snapshots/bool_comparison__lint_ba56854c55bd3954b56d4e0c3d32b65cd144d55b060637c5ff8085d81bef6c49.snap
+++ b/bin/tests/snapshots/bool_comparison__lint_ba56854c55bd3954b56d4e0c3d32b65cd144d55b060637c5ff8085d81bef6c49.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/bool_comparison.rs
-expression: "\"false == true\""
+expression: snapshot
+---
+expression:
+false == true
 ---
 [W01] Warning: Equality comparison between boolean literals
    ╭─[<temp_file_path>:1:1]

--- a/bin/tests/snapshots/bool_comparison__lint_e242c6e0c4298e00ab2cae2f89de63cc77e833cf6ad2c8eb1047a38df7f25564.snap
+++ b/bin/tests/snapshots/bool_comparison__lint_e242c6e0c4298e00ab2cae2f89de63cc77e833cf6ad2c8eb1047a38df7f25564.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/bool_comparison.rs
-expression: "\"false != false\""
+expression: snapshot
+---
+expression:
+false != false
 ---
 [W01] Warning: Equality comparison between boolean literals
    ╭─[<temp_file_path>:1:1]

--- a/bin/tests/snapshots/bool_comparison__lint_e242c6e0c4298e00ab2cae2f89de63cc77e833cf6ad2c8eb1047a38df7f25564.snap
+++ b/bin/tests/snapshots/bool_comparison__lint_e242c6e0c4298e00ab2cae2f89de63cc77e833cf6ad2c8eb1047a38df7f25564.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/bool_comparison.rs
 ---
-expression:
 false != false
 ---
 [W01] Warning: Equality comparison between boolean literals

--- a/bin/tests/snapshots/bool_comparison__lint_e242c6e0c4298e00ab2cae2f89de63cc77e833cf6ad2c8eb1047a38df7f25564.snap
+++ b/bin/tests/snapshots/bool_comparison__lint_e242c6e0c4298e00ab2cae2f89de63cc77e833cf6ad2c8eb1047a38df7f25564.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_comparison.rs
-expression: snapshot
 ---
 expression:
 false != false

--- a/bin/tests/snapshots/bool_comparison__lint_eb450df0fb6d76e9df94f175a6b87a7c1a667495e18432ed8f38540fd051cec1.snap
+++ b/bin/tests/snapshots/bool_comparison__lint_eb450df0fb6d76e9df94f175a6b87a7c1a667495e18432ed8f38540fd051cec1.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_comparison.rs
-expression: snapshot
 ---
 expression:
 true == false

--- a/bin/tests/snapshots/bool_comparison__lint_eb450df0fb6d76e9df94f175a6b87a7c1a667495e18432ed8f38540fd051cec1.snap
+++ b/bin/tests/snapshots/bool_comparison__lint_eb450df0fb6d76e9df94f175a6b87a7c1a667495e18432ed8f38540fd051cec1.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/bool_comparison.rs
 ---
-expression:
 true == false
 ---
 [W01] Warning: Equality comparison between boolean literals

--- a/bin/tests/snapshots/bool_comparison__lint_eb450df0fb6d76e9df94f175a6b87a7c1a667495e18432ed8f38540fd051cec1.snap
+++ b/bin/tests/snapshots/bool_comparison__lint_eb450df0fb6d76e9df94f175a6b87a7c1a667495e18432ed8f38540fd051cec1.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/bool_comparison.rs
-expression: "\"true == false\""
+expression: snapshot
+---
+expression:
+true == false
 ---
 [W01] Warning: Equality comparison between boolean literals
    ╭─[<temp_file_path>:1:1]

--- a/bin/tests/snapshots/bool_simplification__fix_b01828755e286c145f9a8ae65cde7a14eb9e252d7bb6f72fb3d934dff9400353.snap
+++ b/bin/tests/snapshots/bool_simplification__fix_b01828755e286c145f9a8ae65cde7a14eb9e252d7bb6f72fb3d934dff9400353.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/bool_simplification.rs
 ---
-expression:
 !(a == b)
 ---
 --- <temp_file_path>

--- a/bin/tests/snapshots/bool_simplification__fix_b01828755e286c145f9a8ae65cde7a14eb9e252d7bb6f72fb3d934dff9400353.snap
+++ b/bin/tests/snapshots/bool_simplification__fix_b01828755e286c145f9a8ae65cde7a14eb9e252d7bb6f72fb3d934dff9400353.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/bool_simplification.rs
-expression: "\"!(a == b)\""
+expression: snapshot
+---
+expression:
+!(a == b)
 ---
 --- <temp_file_path>
 +++ <temp_file_path> [fixed]

--- a/bin/tests/snapshots/bool_simplification__fix_b01828755e286c145f9a8ae65cde7a14eb9e252d7bb6f72fb3d934dff9400353.snap
+++ b/bin/tests/snapshots/bool_simplification__fix_b01828755e286c145f9a8ae65cde7a14eb9e252d7bb6f72fb3d934dff9400353.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_simplification.rs
-expression: snapshot
 ---
 expression:
 !(a == b)

--- a/bin/tests/snapshots/bool_simplification__fix_dba01b31497c8add1ca9c98db9ec7d205af95f5e9c8904c94cc3adc9889f8d40.snap
+++ b/bin/tests/snapshots/bool_simplification__fix_dba01b31497c8add1ca9c98db9ec7d205af95f5e9c8904c94cc3adc9889f8d40.snap
@@ -1,5 +1,7 @@
 ---
 source: bin/tests/bool_simplification.rs
-expression: "\"a != b\""
+expression: snapshot
 ---
-
+expression:
+a != b
+---

--- a/bin/tests/snapshots/bool_simplification__fix_dba01b31497c8add1ca9c98db9ec7d205af95f5e9c8904c94cc3adc9889f8d40.snap
+++ b/bin/tests/snapshots/bool_simplification__fix_dba01b31497c8add1ca9c98db9ec7d205af95f5e9c8904c94cc3adc9889f8d40.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_simplification.rs
-expression: snapshot
 ---
 expression:
 a != b

--- a/bin/tests/snapshots/bool_simplification__fix_dba01b31497c8add1ca9c98db9ec7d205af95f5e9c8904c94cc3adc9889f8d40.snap
+++ b/bin/tests/snapshots/bool_simplification__fix_dba01b31497c8add1ca9c98db9ec7d205af95f5e9c8904c94cc3adc9889f8d40.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_simplification.rs
 ---
-expression:
 a != b
 ---

--- a/bin/tests/snapshots/bool_simplification__fix_fc74617cbe767e6731b7fbce9bf425fe8a017be2bebd70050bbe01f40a45f066.snap
+++ b/bin/tests/snapshots/bool_simplification__fix_fc74617cbe767e6731b7fbce9bf425fe8a017be2bebd70050bbe01f40a45f066.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_simplification.rs
 ---
-expression:
 !(a != b)
 ---

--- a/bin/tests/snapshots/bool_simplification__fix_fc74617cbe767e6731b7fbce9bf425fe8a017be2bebd70050bbe01f40a45f066.snap
+++ b/bin/tests/snapshots/bool_simplification__fix_fc74617cbe767e6731b7fbce9bf425fe8a017be2bebd70050bbe01f40a45f066.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_simplification.rs
-expression: snapshot
 ---
 expression:
 !(a != b)

--- a/bin/tests/snapshots/bool_simplification__fix_fc74617cbe767e6731b7fbce9bf425fe8a017be2bebd70050bbe01f40a45f066.snap
+++ b/bin/tests/snapshots/bool_simplification__fix_fc74617cbe767e6731b7fbce9bf425fe8a017be2bebd70050bbe01f40a45f066.snap
@@ -1,5 +1,7 @@
 ---
 source: bin/tests/bool_simplification.rs
-expression: "\"!(a != b)\""
+expression: snapshot
 ---
-
+expression:
+!(a != b)
+---

--- a/bin/tests/snapshots/bool_simplification__lint_b01828755e286c145f9a8ae65cde7a14eb9e252d7bb6f72fb3d934dff9400353.snap
+++ b/bin/tests/snapshots/bool_simplification__lint_b01828755e286c145f9a8ae65cde7a14eb9e252d7bb6f72fb3d934dff9400353.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/bool_simplification.rs
-expression: "\"!(a == b)\""
+expression: snapshot
+---
+expression:
+!(a == b)
 ---
 [W18] Warning: This boolean expression can be simplified
    ╭─[<temp_file_path>:1:1]

--- a/bin/tests/snapshots/bool_simplification__lint_b01828755e286c145f9a8ae65cde7a14eb9e252d7bb6f72fb3d934dff9400353.snap
+++ b/bin/tests/snapshots/bool_simplification__lint_b01828755e286c145f9a8ae65cde7a14eb9e252d7bb6f72fb3d934dff9400353.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/bool_simplification.rs
 ---
-expression:
 !(a == b)
 ---
 [W18] Warning: This boolean expression can be simplified

--- a/bin/tests/snapshots/bool_simplification__lint_b01828755e286c145f9a8ae65cde7a14eb9e252d7bb6f72fb3d934dff9400353.snap
+++ b/bin/tests/snapshots/bool_simplification__lint_b01828755e286c145f9a8ae65cde7a14eb9e252d7bb6f72fb3d934dff9400353.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_simplification.rs
-expression: snapshot
 ---
 expression:
 !(a == b)

--- a/bin/tests/snapshots/bool_simplification__lint_dba01b31497c8add1ca9c98db9ec7d205af95f5e9c8904c94cc3adc9889f8d40.snap
+++ b/bin/tests/snapshots/bool_simplification__lint_dba01b31497c8add1ca9c98db9ec7d205af95f5e9c8904c94cc3adc9889f8d40.snap
@@ -1,5 +1,7 @@
 ---
 source: bin/tests/bool_simplification.rs
-expression: "\"a != b\""
+expression: snapshot
 ---
-
+expression:
+a != b
+---

--- a/bin/tests/snapshots/bool_simplification__lint_dba01b31497c8add1ca9c98db9ec7d205af95f5e9c8904c94cc3adc9889f8d40.snap
+++ b/bin/tests/snapshots/bool_simplification__lint_dba01b31497c8add1ca9c98db9ec7d205af95f5e9c8904c94cc3adc9889f8d40.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_simplification.rs
-expression: snapshot
 ---
 expression:
 a != b

--- a/bin/tests/snapshots/bool_simplification__lint_dba01b31497c8add1ca9c98db9ec7d205af95f5e9c8904c94cc3adc9889f8d40.snap
+++ b/bin/tests/snapshots/bool_simplification__lint_dba01b31497c8add1ca9c98db9ec7d205af95f5e9c8904c94cc3adc9889f8d40.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_simplification.rs
 ---
-expression:
 a != b
 ---

--- a/bin/tests/snapshots/bool_simplification__lint_fc74617cbe767e6731b7fbce9bf425fe8a017be2bebd70050bbe01f40a45f066.snap
+++ b/bin/tests/snapshots/bool_simplification__lint_fc74617cbe767e6731b7fbce9bf425fe8a017be2bebd70050bbe01f40a45f066.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_simplification.rs
 ---
-expression:
 !(a != b)
 ---

--- a/bin/tests/snapshots/bool_simplification__lint_fc74617cbe767e6731b7fbce9bf425fe8a017be2bebd70050bbe01f40a45f066.snap
+++ b/bin/tests/snapshots/bool_simplification__lint_fc74617cbe767e6731b7fbce9bf425fe8a017be2bebd70050bbe01f40a45f066.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/bool_simplification.rs
-expression: snapshot
 ---
 expression:
 !(a != b)

--- a/bin/tests/snapshots/bool_simplification__lint_fc74617cbe767e6731b7fbce9bf425fe8a017be2bebd70050bbe01f40a45f066.snap
+++ b/bin/tests/snapshots/bool_simplification__lint_fc74617cbe767e6731b7fbce9bf425fe8a017be2bebd70050bbe01f40a45f066.snap
@@ -1,5 +1,7 @@
 ---
 source: bin/tests/bool_simplification.rs
-expression: "\"!(a != b)\""
+expression: snapshot
 ---
-
+expression:
+!(a != b)
+---

--- a/bin/tests/snapshots/collapsible_let_in__fix_950e48dec6590cd20937e48006bff3f7c097bd07ec2da4a7b5dba488885061aa.snap
+++ b/bin/tests/snapshots/collapsible_let_in__fix_950e48dec6590cd20937e48006bff3f7c097bd07ec2da4a7b5dba488885061aa.snap
@@ -1,6 +1,18 @@
 ---
 source: bin/tests/collapsible_let_in.rs
-expression: "\"let\\n  a = 2;\\n  b = 3;\\nin\\n  let\\n    c = 5;\\n    d = 6;\\n  in\\n  a + b + c + d\\n\""
+expression: snapshot
+---
+expression:
+let
+  a = 2;
+  b = 3;
+in
+  let
+    c = 5;
+    d = 6;
+  in
+  a + b + c + d
+
 ---
 --- <temp_file_path>
 +++ <temp_file_path> [fixed]

--- a/bin/tests/snapshots/collapsible_let_in__fix_950e48dec6590cd20937e48006bff3f7c097bd07ec2da4a7b5dba488885061aa.snap
+++ b/bin/tests/snapshots/collapsible_let_in__fix_950e48dec6590cd20937e48006bff3f7c097bd07ec2da4a7b5dba488885061aa.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/collapsible_let_in.rs
 ---
-expression:
 let
   a = 2;
   b = 3;

--- a/bin/tests/snapshots/collapsible_let_in__fix_950e48dec6590cd20937e48006bff3f7c097bd07ec2da4a7b5dba488885061aa.snap
+++ b/bin/tests/snapshots/collapsible_let_in__fix_950e48dec6590cd20937e48006bff3f7c097bd07ec2da4a7b5dba488885061aa.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/collapsible_let_in.rs
-expression: snapshot
 ---
 expression:
 let

--- a/bin/tests/snapshots/collapsible_let_in__lint_950e48dec6590cd20937e48006bff3f7c097bd07ec2da4a7b5dba488885061aa.snap
+++ b/bin/tests/snapshots/collapsible_let_in__lint_950e48dec6590cd20937e48006bff3f7c097bd07ec2da4a7b5dba488885061aa.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/collapsible_let_in.rs
 ---
-expression:
 let
   a = 2;
   b = 3;

--- a/bin/tests/snapshots/collapsible_let_in__lint_950e48dec6590cd20937e48006bff3f7c097bd07ec2da4a7b5dba488885061aa.snap
+++ b/bin/tests/snapshots/collapsible_let_in__lint_950e48dec6590cd20937e48006bff3f7c097bd07ec2da4a7b5dba488885061aa.snap
@@ -1,6 +1,18 @@
 ---
 source: bin/tests/collapsible_let_in.rs
-expression: "\"let\\n  a = 2;\\n  b = 3;\\nin\\n  let\\n    c = 5;\\n    d = 6;\\n  in\\n  a + b + c + d\\n\""
+expression: snapshot
+---
+expression:
+let
+  a = 2;
+  b = 3;
+in
+  let
+    c = 5;
+    d = 6;
+  in
+  a + b + c + d
+
 ---
 [W06] Warning: These let-in expressions are collapsible
    ╭─[<temp_file_path>:1:1]

--- a/bin/tests/snapshots/collapsible_let_in__lint_950e48dec6590cd20937e48006bff3f7c097bd07ec2da4a7b5dba488885061aa.snap
+++ b/bin/tests/snapshots/collapsible_let_in__lint_950e48dec6590cd20937e48006bff3f7c097bd07ec2da4a7b5dba488885061aa.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/collapsible_let_in.rs
-expression: snapshot
 ---
 expression:
 let

--- a/bin/tests/snapshots/deprecated_to_path__fix_174dc0d1d9e78fd30b854475b82a991795814e0bfc6a3fc90f46e7370f2f63dc.snap
+++ b/bin/tests/snapshots/deprecated_to_path__fix_174dc0d1d9e78fd30b854475b82a991795814e0bfc6a3fc90f46e7370f2f63dc.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/deprecated_to_path.rs
-expression: snapshot
 ---
 expression:
 builtins.toPath "/some/path"

--- a/bin/tests/snapshots/deprecated_to_path__fix_174dc0d1d9e78fd30b854475b82a991795814e0bfc6a3fc90f46e7370f2f63dc.snap
+++ b/bin/tests/snapshots/deprecated_to_path__fix_174dc0d1d9e78fd30b854475b82a991795814e0bfc6a3fc90f46e7370f2f63dc.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/deprecated_to_path.rs
 ---
-expression:
 builtins.toPath "/some/path"
 ---

--- a/bin/tests/snapshots/deprecated_to_path__fix_174dc0d1d9e78fd30b854475b82a991795814e0bfc6a3fc90f46e7370f2f63dc.snap
+++ b/bin/tests/snapshots/deprecated_to_path__fix_174dc0d1d9e78fd30b854475b82a991795814e0bfc6a3fc90f46e7370f2f63dc.snap
@@ -1,5 +1,7 @@
 ---
 source: bin/tests/deprecated_to_path.rs
-expression: "\"builtins.toPath \\\"/some/path\\\"\""
+expression: snapshot
 ---
-
+expression:
+builtins.toPath "/some/path"
+---

--- a/bin/tests/snapshots/deprecated_to_path__fix_4f2c5321b7dbd2171c77729c879745a1f6209972b4a9d367bd5fb41a83c42e99.snap
+++ b/bin/tests/snapshots/deprecated_to_path__fix_4f2c5321b7dbd2171c77729c879745a1f6209972b4a9d367bd5fb41a83c42e99.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/deprecated_to_path.rs
 ---
-expression:
 toPath x
 ---

--- a/bin/tests/snapshots/deprecated_to_path__fix_4f2c5321b7dbd2171c77729c879745a1f6209972b4a9d367bd5fb41a83c42e99.snap
+++ b/bin/tests/snapshots/deprecated_to_path__fix_4f2c5321b7dbd2171c77729c879745a1f6209972b4a9d367bd5fb41a83c42e99.snap
@@ -1,5 +1,7 @@
 ---
 source: bin/tests/deprecated_to_path.rs
-expression: "\"toPath x\""
+expression: snapshot
 ---
-
+expression:
+toPath x
+---

--- a/bin/tests/snapshots/deprecated_to_path__fix_4f2c5321b7dbd2171c77729c879745a1f6209972b4a9d367bd5fb41a83c42e99.snap
+++ b/bin/tests/snapshots/deprecated_to_path__fix_4f2c5321b7dbd2171c77729c879745a1f6209972b4a9d367bd5fb41a83c42e99.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/deprecated_to_path.rs
-expression: snapshot
 ---
 expression:
 toPath x

--- a/bin/tests/snapshots/deprecated_to_path__fix_b7ca5bc4bbe1fe57468d47f2df8fac29361ae090a84ea6afdea842170517ae14.snap
+++ b/bin/tests/snapshots/deprecated_to_path__fix_b7ca5bc4bbe1fe57468d47f2df8fac29361ae090a84ea6afdea842170517ae14.snap
@@ -1,5 +1,7 @@
 ---
 source: bin/tests/deprecated_to_path.rs
-expression: "\"builtins.toPath x\""
+expression: snapshot
 ---
-
+expression:
+builtins.toPath x
+---

--- a/bin/tests/snapshots/deprecated_to_path__fix_b7ca5bc4bbe1fe57468d47f2df8fac29361ae090a84ea6afdea842170517ae14.snap
+++ b/bin/tests/snapshots/deprecated_to_path__fix_b7ca5bc4bbe1fe57468d47f2df8fac29361ae090a84ea6afdea842170517ae14.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/deprecated_to_path.rs
 ---
-expression:
 builtins.toPath x
 ---

--- a/bin/tests/snapshots/deprecated_to_path__fix_b7ca5bc4bbe1fe57468d47f2df8fac29361ae090a84ea6afdea842170517ae14.snap
+++ b/bin/tests/snapshots/deprecated_to_path__fix_b7ca5bc4bbe1fe57468d47f2df8fac29361ae090a84ea6afdea842170517ae14.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/deprecated_to_path.rs
-expression: snapshot
 ---
 expression:
 builtins.toPath x

--- a/bin/tests/snapshots/deprecated_to_path__fix_babcf3ca5fe7ee69b692a0e6ccfbfdf4f08823229d054ee85af87dc3d52d41ea.snap
+++ b/bin/tests/snapshots/deprecated_to_path__fix_babcf3ca5fe7ee69b692a0e6ccfbfdf4f08823229d054ee85af87dc3d52d41ea.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/deprecated_to_path.rs
 ---
-expression:
 toPath "/abc/def"
 ---

--- a/bin/tests/snapshots/deprecated_to_path__fix_babcf3ca5fe7ee69b692a0e6ccfbfdf4f08823229d054ee85af87dc3d52d41ea.snap
+++ b/bin/tests/snapshots/deprecated_to_path__fix_babcf3ca5fe7ee69b692a0e6ccfbfdf4f08823229d054ee85af87dc3d52d41ea.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/deprecated_to_path.rs
-expression: snapshot
 ---
 expression:
 toPath "/abc/def"

--- a/bin/tests/snapshots/deprecated_to_path__fix_babcf3ca5fe7ee69b692a0e6ccfbfdf4f08823229d054ee85af87dc3d52d41ea.snap
+++ b/bin/tests/snapshots/deprecated_to_path__fix_babcf3ca5fe7ee69b692a0e6ccfbfdf4f08823229d054ee85af87dc3d52d41ea.snap
@@ -1,5 +1,7 @@
 ---
 source: bin/tests/deprecated_to_path.rs
-expression: "\"toPath \\\"/abc/def\\\"\""
+expression: snapshot
 ---
-
+expression:
+toPath "/abc/def"
+---

--- a/bin/tests/snapshots/deprecated_to_path__lint_174dc0d1d9e78fd30b854475b82a991795814e0bfc6a3fc90f46e7370f2f63dc.snap
+++ b/bin/tests/snapshots/deprecated_to_path__lint_174dc0d1d9e78fd30b854475b82a991795814e0bfc6a3fc90f46e7370f2f63dc.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/deprecated_to_path.rs
 ---
-expression:
 builtins.toPath "/some/path"
 ---
 [W17] Warning: Found usage of deprecated builtin toPath

--- a/bin/tests/snapshots/deprecated_to_path__lint_174dc0d1d9e78fd30b854475b82a991795814e0bfc6a3fc90f46e7370f2f63dc.snap
+++ b/bin/tests/snapshots/deprecated_to_path__lint_174dc0d1d9e78fd30b854475b82a991795814e0bfc6a3fc90f46e7370f2f63dc.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/deprecated_to_path.rs
-expression: snapshot
 ---
 expression:
 builtins.toPath "/some/path"

--- a/bin/tests/snapshots/deprecated_to_path__lint_174dc0d1d9e78fd30b854475b82a991795814e0bfc6a3fc90f46e7370f2f63dc.snap
+++ b/bin/tests/snapshots/deprecated_to_path__lint_174dc0d1d9e78fd30b854475b82a991795814e0bfc6a3fc90f46e7370f2f63dc.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/deprecated_to_path.rs
-expression: "\"builtins.toPath \\\"/some/path\\\"\""
+expression: snapshot
+---
+expression:
+builtins.toPath "/some/path"
 ---
 [W17] Warning: Found usage of deprecated builtin toPath
    ╭─[<temp_file_path>:1:1]

--- a/bin/tests/snapshots/deprecated_to_path__lint_4f2c5321b7dbd2171c77729c879745a1f6209972b4a9d367bd5fb41a83c42e99.snap
+++ b/bin/tests/snapshots/deprecated_to_path__lint_4f2c5321b7dbd2171c77729c879745a1f6209972b4a9d367bd5fb41a83c42e99.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/deprecated_to_path.rs
-expression: "\"toPath x\""
+expression: snapshot
+---
+expression:
+toPath x
 ---
 [W17] Warning: Found usage of deprecated builtin toPath
    ╭─[<temp_file_path>:1:1]

--- a/bin/tests/snapshots/deprecated_to_path__lint_4f2c5321b7dbd2171c77729c879745a1f6209972b4a9d367bd5fb41a83c42e99.snap
+++ b/bin/tests/snapshots/deprecated_to_path__lint_4f2c5321b7dbd2171c77729c879745a1f6209972b4a9d367bd5fb41a83c42e99.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/deprecated_to_path.rs
 ---
-expression:
 toPath x
 ---
 [W17] Warning: Found usage of deprecated builtin toPath

--- a/bin/tests/snapshots/deprecated_to_path__lint_4f2c5321b7dbd2171c77729c879745a1f6209972b4a9d367bd5fb41a83c42e99.snap
+++ b/bin/tests/snapshots/deprecated_to_path__lint_4f2c5321b7dbd2171c77729c879745a1f6209972b4a9d367bd5fb41a83c42e99.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/deprecated_to_path.rs
-expression: snapshot
 ---
 expression:
 toPath x

--- a/bin/tests/snapshots/deprecated_to_path__lint_b7ca5bc4bbe1fe57468d47f2df8fac29361ae090a84ea6afdea842170517ae14.snap
+++ b/bin/tests/snapshots/deprecated_to_path__lint_b7ca5bc4bbe1fe57468d47f2df8fac29361ae090a84ea6afdea842170517ae14.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/deprecated_to_path.rs
-expression: "\"builtins.toPath x\""
+expression: snapshot
+---
+expression:
+builtins.toPath x
 ---
 [W17] Warning: Found usage of deprecated builtin toPath
    ╭─[<temp_file_path>:1:1]

--- a/bin/tests/snapshots/deprecated_to_path__lint_b7ca5bc4bbe1fe57468d47f2df8fac29361ae090a84ea6afdea842170517ae14.snap
+++ b/bin/tests/snapshots/deprecated_to_path__lint_b7ca5bc4bbe1fe57468d47f2df8fac29361ae090a84ea6afdea842170517ae14.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/deprecated_to_path.rs
-expression: snapshot
 ---
 expression:
 builtins.toPath x

--- a/bin/tests/snapshots/deprecated_to_path__lint_b7ca5bc4bbe1fe57468d47f2df8fac29361ae090a84ea6afdea842170517ae14.snap
+++ b/bin/tests/snapshots/deprecated_to_path__lint_b7ca5bc4bbe1fe57468d47f2df8fac29361ae090a84ea6afdea842170517ae14.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/deprecated_to_path.rs
 ---
-expression:
 builtins.toPath x
 ---
 [W17] Warning: Found usage of deprecated builtin toPath

--- a/bin/tests/snapshots/deprecated_to_path__lint_babcf3ca5fe7ee69b692a0e6ccfbfdf4f08823229d054ee85af87dc3d52d41ea.snap
+++ b/bin/tests/snapshots/deprecated_to_path__lint_babcf3ca5fe7ee69b692a0e6ccfbfdf4f08823229d054ee85af87dc3d52d41ea.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/deprecated_to_path.rs
 ---
-expression:
 toPath "/abc/def"
 ---
 [W17] Warning: Found usage of deprecated builtin toPath

--- a/bin/tests/snapshots/deprecated_to_path__lint_babcf3ca5fe7ee69b692a0e6ccfbfdf4f08823229d054ee85af87dc3d52d41ea.snap
+++ b/bin/tests/snapshots/deprecated_to_path__lint_babcf3ca5fe7ee69b692a0e6ccfbfdf4f08823229d054ee85af87dc3d52d41ea.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/deprecated_to_path.rs
-expression: snapshot
 ---
 expression:
 toPath "/abc/def"

--- a/bin/tests/snapshots/deprecated_to_path__lint_babcf3ca5fe7ee69b692a0e6ccfbfdf4f08823229d054ee85af87dc3d52d41ea.snap
+++ b/bin/tests/snapshots/deprecated_to_path__lint_babcf3ca5fe7ee69b692a0e6ccfbfdf4f08823229d054ee85af87dc3d52d41ea.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/deprecated_to_path.rs
-expression: "\"toPath \\\"/abc/def\\\"\""
+expression: snapshot
+---
+expression:
+toPath "/abc/def"
 ---
 [W17] Warning: Found usage of deprecated builtin toPath
    ╭─[<temp_file_path>:1:1]

--- a/bin/tests/snapshots/empty_inherit__fix_2370f348818d984736674ed594a500980e67c68740a68810e6d7ad6e42e95cad.snap
+++ b/bin/tests/snapshots/empty_inherit__fix_2370f348818d984736674ed594a500980e67c68740a68810e6d7ad6e42e95cad.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/empty_inherit.rs
-expression: "\"{ inherit; }\""
+expression: snapshot
+---
+expression:
+{ inherit; }
 ---
 --- <temp_file_path>
 +++ <temp_file_path> [fixed]

--- a/bin/tests/snapshots/empty_inherit__fix_2370f348818d984736674ed594a500980e67c68740a68810e6d7ad6e42e95cad.snap
+++ b/bin/tests/snapshots/empty_inherit__fix_2370f348818d984736674ed594a500980e67c68740a68810e6d7ad6e42e95cad.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/empty_inherit.rs
-expression: snapshot
 ---
 expression:
 { inherit; }

--- a/bin/tests/snapshots/empty_inherit__fix_2370f348818d984736674ed594a500980e67c68740a68810e6d7ad6e42e95cad.snap
+++ b/bin/tests/snapshots/empty_inherit__fix_2370f348818d984736674ed594a500980e67c68740a68810e6d7ad6e42e95cad.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/empty_inherit.rs
 ---
-expression:
 { inherit; }
 ---
 --- <temp_file_path>

--- a/bin/tests/snapshots/empty_inherit__lint_2370f348818d984736674ed594a500980e67c68740a68810e6d7ad6e42e95cad.snap
+++ b/bin/tests/snapshots/empty_inherit__lint_2370f348818d984736674ed594a500980e67c68740a68810e6d7ad6e42e95cad.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/empty_inherit.rs
-expression: "\"{ inherit; }\""
+expression: snapshot
+---
+expression:
+{ inherit; }
 ---
 [W14] Warning: Found empty inherit statement
    ╭─[<temp_file_path>:1:3]

--- a/bin/tests/snapshots/empty_inherit__lint_2370f348818d984736674ed594a500980e67c68740a68810e6d7ad6e42e95cad.snap
+++ b/bin/tests/snapshots/empty_inherit__lint_2370f348818d984736674ed594a500980e67c68740a68810e6d7ad6e42e95cad.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/empty_inherit.rs
-expression: snapshot
 ---
 expression:
 { inherit; }

--- a/bin/tests/snapshots/empty_inherit__lint_2370f348818d984736674ed594a500980e67c68740a68810e6d7ad6e42e95cad.snap
+++ b/bin/tests/snapshots/empty_inherit__lint_2370f348818d984736674ed594a500980e67c68740a68810e6d7ad6e42e95cad.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/empty_inherit.rs
 ---
-expression:
 { inherit; }
 ---
 [W14] Warning: Found empty inherit statement

--- a/bin/tests/snapshots/empty_let_in__fix_5c1128abfe4ef6b1ed846295f216703aa1c58b4fcadad40bc25e05858c3bdd08.snap
+++ b/bin/tests/snapshots/empty_let_in__fix_5c1128abfe4ef6b1ed846295f216703aa1c58b4fcadad40bc25e05858c3bdd08.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/empty_let_in.rs
 ---
-expression:
 let in null
 ---
 --- <temp_file_path>

--- a/bin/tests/snapshots/empty_let_in__fix_5c1128abfe4ef6b1ed846295f216703aa1c58b4fcadad40bc25e05858c3bdd08.snap
+++ b/bin/tests/snapshots/empty_let_in__fix_5c1128abfe4ef6b1ed846295f216703aa1c58b4fcadad40bc25e05858c3bdd08.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/empty_let_in.rs
-expression: "\"let in null\""
+expression: snapshot
+---
+expression:
+let in null
 ---
 --- <temp_file_path>
 +++ <temp_file_path> [fixed]

--- a/bin/tests/snapshots/empty_let_in__fix_5c1128abfe4ef6b1ed846295f216703aa1c58b4fcadad40bc25e05858c3bdd08.snap
+++ b/bin/tests/snapshots/empty_let_in__fix_5c1128abfe4ef6b1ed846295f216703aa1c58b4fcadad40bc25e05858c3bdd08.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/empty_let_in.rs
-expression: snapshot
 ---
 expression:
 let in null

--- a/bin/tests/snapshots/empty_let_in__fix_69e2d9e348a3b7903ae167887886709559b8d299d9ea097621bbbab32e6f3bfa.snap
+++ b/bin/tests/snapshots/empty_let_in__fix_69e2d9e348a3b7903ae167887886709559b8d299d9ea097621bbbab32e6f3bfa.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/empty_let_in.rs
 ---
-expression:
 let
   # don't fix this, we have a comment
   # raise the lint though

--- a/bin/tests/snapshots/empty_let_in__fix_69e2d9e348a3b7903ae167887886709559b8d299d9ea097621bbbab32e6f3bfa.snap
+++ b/bin/tests/snapshots/empty_let_in__fix_69e2d9e348a3b7903ae167887886709559b8d299d9ea097621bbbab32e6f3bfa.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/empty_let_in.rs
-expression: snapshot
 ---
 expression:
 let

--- a/bin/tests/snapshots/empty_let_in__fix_69e2d9e348a3b7903ae167887886709559b8d299d9ea097621bbbab32e6f3bfa.snap
+++ b/bin/tests/snapshots/empty_let_in__fix_69e2d9e348a3b7903ae167887886709559b8d299d9ea097621bbbab32e6f3bfa.snap
@@ -1,5 +1,12 @@
 ---
 source: bin/tests/empty_let_in.rs
-expression: "\"let\\n  # don't fix this, we have a comment\\n  # raise the lint though\\nin\\nnull\\n\""
+expression: snapshot
 ---
+expression:
+let
+  # don't fix this, we have a comment
+  # raise the lint though
+in
+null
 
+---

--- a/bin/tests/snapshots/empty_let_in__lint_5c1128abfe4ef6b1ed846295f216703aa1c58b4fcadad40bc25e05858c3bdd08.snap
+++ b/bin/tests/snapshots/empty_let_in__lint_5c1128abfe4ef6b1ed846295f216703aa1c58b4fcadad40bc25e05858c3bdd08.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/empty_let_in.rs
-expression: "\"let in null\""
+expression: snapshot
+---
+expression:
+let in null
 ---
 [W02] Warning: Useless let-in expression
    ╭─[<temp_file_path>:1:1]

--- a/bin/tests/snapshots/empty_let_in__lint_5c1128abfe4ef6b1ed846295f216703aa1c58b4fcadad40bc25e05858c3bdd08.snap
+++ b/bin/tests/snapshots/empty_let_in__lint_5c1128abfe4ef6b1ed846295f216703aa1c58b4fcadad40bc25e05858c3bdd08.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/empty_let_in.rs
-expression: snapshot
 ---
 expression:
 let in null

--- a/bin/tests/snapshots/empty_let_in__lint_5c1128abfe4ef6b1ed846295f216703aa1c58b4fcadad40bc25e05858c3bdd08.snap
+++ b/bin/tests/snapshots/empty_let_in__lint_5c1128abfe4ef6b1ed846295f216703aa1c58b4fcadad40bc25e05858c3bdd08.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/empty_let_in.rs
 ---
-expression:
 let in null
 ---
 [W02] Warning: Useless let-in expression

--- a/bin/tests/snapshots/empty_let_in__lint_69e2d9e348a3b7903ae167887886709559b8d299d9ea097621bbbab32e6f3bfa.snap
+++ b/bin/tests/snapshots/empty_let_in__lint_69e2d9e348a3b7903ae167887886709559b8d299d9ea097621bbbab32e6f3bfa.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/empty_let_in.rs
 ---
-expression:
 let
   # don't fix this, we have a comment
   # raise the lint though

--- a/bin/tests/snapshots/empty_let_in__lint_69e2d9e348a3b7903ae167887886709559b8d299d9ea097621bbbab32e6f3bfa.snap
+++ b/bin/tests/snapshots/empty_let_in__lint_69e2d9e348a3b7903ae167887886709559b8d299d9ea097621bbbab32e6f3bfa.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/empty_let_in.rs
-expression: snapshot
 ---
 expression:
 let

--- a/bin/tests/snapshots/empty_let_in__lint_69e2d9e348a3b7903ae167887886709559b8d299d9ea097621bbbab32e6f3bfa.snap
+++ b/bin/tests/snapshots/empty_let_in__lint_69e2d9e348a3b7903ae167887886709559b8d299d9ea097621bbbab32e6f3bfa.snap
@@ -1,6 +1,14 @@
 ---
 source: bin/tests/empty_let_in.rs
-expression: "\"let\\n  # don't fix this, we have a comment\\n  # raise the lint though\\nin\\nnull\\n\""
+expression: snapshot
+---
+expression:
+let
+  # don't fix this, we have a comment
+  # raise the lint though
+in
+null
+
 ---
 [W02] Warning: Useless let-in expression
    ╭─[<temp_file_path>:1:1]

--- a/bin/tests/snapshots/empty_list_concat__fix_676800f4240e26802590a123362636e6d87461d7e091b87b44fb8b5959b31b1a.snap
+++ b/bin/tests/snapshots/empty_list_concat__fix_676800f4240e26802590a123362636e6d87461d7e091b87b44fb8b5959b31b1a.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/empty_list_concat.rs
 ---
-expression:
 [1 2 3] ++ []
 ---
 --- <temp_file_path>

--- a/bin/tests/snapshots/empty_list_concat__fix_676800f4240e26802590a123362636e6d87461d7e091b87b44fb8b5959b31b1a.snap
+++ b/bin/tests/snapshots/empty_list_concat__fix_676800f4240e26802590a123362636e6d87461d7e091b87b44fb8b5959b31b1a.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/empty_list_concat.rs
-expression: "\"[1 2 3] ++ []\""
+expression: snapshot
+---
+expression:
+[1 2 3] ++ []
 ---
 --- <temp_file_path>
 +++ <temp_file_path> [fixed]

--- a/bin/tests/snapshots/empty_list_concat__fix_676800f4240e26802590a123362636e6d87461d7e091b87b44fb8b5959b31b1a.snap
+++ b/bin/tests/snapshots/empty_list_concat__fix_676800f4240e26802590a123362636e6d87461d7e091b87b44fb8b5959b31b1a.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/empty_list_concat.rs
-expression: snapshot
 ---
 expression:
 [1 2 3] ++ []

--- a/bin/tests/snapshots/empty_list_concat__fix_6d44e9727e67c4d4d91c4b7abe2a2193f00467aabdd6230c1019702fdabe53bb.snap
+++ b/bin/tests/snapshots/empty_list_concat__fix_6d44e9727e67c4d4d91c4b7abe2a2193f00467aabdd6230c1019702fdabe53bb.snap
@@ -1,5 +1,7 @@
 ---
 source: bin/tests/empty_list_concat.rs
-expression: "\"[1 2] ++ [3 4]\""
+expression: snapshot
 ---
-
+expression:
+[1 2] ++ [3 4]
+---

--- a/bin/tests/snapshots/empty_list_concat__fix_6d44e9727e67c4d4d91c4b7abe2a2193f00467aabdd6230c1019702fdabe53bb.snap
+++ b/bin/tests/snapshots/empty_list_concat__fix_6d44e9727e67c4d4d91c4b7abe2a2193f00467aabdd6230c1019702fdabe53bb.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/empty_list_concat.rs
 ---
-expression:
 [1 2] ++ [3 4]
 ---

--- a/bin/tests/snapshots/empty_list_concat__fix_6d44e9727e67c4d4d91c4b7abe2a2193f00467aabdd6230c1019702fdabe53bb.snap
+++ b/bin/tests/snapshots/empty_list_concat__fix_6d44e9727e67c4d4d91c4b7abe2a2193f00467aabdd6230c1019702fdabe53bb.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/empty_list_concat.rs
-expression: snapshot
 ---
 expression:
 [1 2] ++ [3 4]

--- a/bin/tests/snapshots/empty_list_concat__fix_b13b2273654200cbc2315c6ceec0dbc9e4479628a5b7250418efeb5911e743b2.snap
+++ b/bin/tests/snapshots/empty_list_concat__fix_b13b2273654200cbc2315c6ceec0dbc9e4479628a5b7250418efeb5911e743b2.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/empty_list_concat.rs
-expression: snapshot
 ---
 expression:
 [] ++ [] ++ []

--- a/bin/tests/snapshots/empty_list_concat__fix_b13b2273654200cbc2315c6ceec0dbc9e4479628a5b7250418efeb5911e743b2.snap
+++ b/bin/tests/snapshots/empty_list_concat__fix_b13b2273654200cbc2315c6ceec0dbc9e4479628a5b7250418efeb5911e743b2.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/empty_list_concat.rs
 ---
-expression:
 [] ++ [] ++ []
 ---
 --- <temp_file_path>

--- a/bin/tests/snapshots/empty_list_concat__fix_b13b2273654200cbc2315c6ceec0dbc9e4479628a5b7250418efeb5911e743b2.snap
+++ b/bin/tests/snapshots/empty_list_concat__fix_b13b2273654200cbc2315c6ceec0dbc9e4479628a5b7250418efeb5911e743b2.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/empty_list_concat.rs
-expression: "\"[] ++ [] ++ []\""
+expression: snapshot
+---
+expression:
+[] ++ [] ++ []
 ---
 --- <temp_file_path>
 +++ <temp_file_path> [fixed]

--- a/bin/tests/snapshots/empty_list_concat__fix_b6d6b2d3b0ff0b3b842e3f816ced62ca22410c59471e767d80ea85a3f7fcc1ef.snap
+++ b/bin/tests/snapshots/empty_list_concat__fix_b6d6b2d3b0ff0b3b842e3f816ced62ca22410c59471e767d80ea85a3f7fcc1ef.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/empty_list_concat.rs
 ---
-expression:
 [] ++ [1 2 3]
 ---
 --- <temp_file_path>

--- a/bin/tests/snapshots/empty_list_concat__fix_b6d6b2d3b0ff0b3b842e3f816ced62ca22410c59471e767d80ea85a3f7fcc1ef.snap
+++ b/bin/tests/snapshots/empty_list_concat__fix_b6d6b2d3b0ff0b3b842e3f816ced62ca22410c59471e767d80ea85a3f7fcc1ef.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/empty_list_concat.rs
-expression: "\"[] ++ [1 2 3]\""
+expression: snapshot
+---
+expression:
+[] ++ [1 2 3]
 ---
 --- <temp_file_path>
 +++ <temp_file_path> [fixed]

--- a/bin/tests/snapshots/empty_list_concat__fix_b6d6b2d3b0ff0b3b842e3f816ced62ca22410c59471e767d80ea85a3f7fcc1ef.snap
+++ b/bin/tests/snapshots/empty_list_concat__fix_b6d6b2d3b0ff0b3b842e3f816ced62ca22410c59471e767d80ea85a3f7fcc1ef.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/empty_list_concat.rs
-expression: snapshot
 ---
 expression:
 [] ++ [1 2 3]

--- a/bin/tests/snapshots/empty_list_concat__fix_df1c6ef98c749f5c410a485b3d0d5d6851ad340d059d1012ed809a04a21a00a9.snap
+++ b/bin/tests/snapshots/empty_list_concat__fix_df1c6ef98c749f5c410a485b3d0d5d6851ad340d059d1012ed809a04a21a00a9.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/empty_list_concat.rs
-expression: snapshot
 ---
 expression:
 [] ++ []

--- a/bin/tests/snapshots/empty_list_concat__fix_df1c6ef98c749f5c410a485b3d0d5d6851ad340d059d1012ed809a04a21a00a9.snap
+++ b/bin/tests/snapshots/empty_list_concat__fix_df1c6ef98c749f5c410a485b3d0d5d6851ad340d059d1012ed809a04a21a00a9.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/empty_list_concat.rs
-expression: "\"[] ++ []\""
+expression: snapshot
+---
+expression:
+[] ++ []
 ---
 --- <temp_file_path>
 +++ <temp_file_path> [fixed]

--- a/bin/tests/snapshots/empty_list_concat__fix_df1c6ef98c749f5c410a485b3d0d5d6851ad340d059d1012ed809a04a21a00a9.snap
+++ b/bin/tests/snapshots/empty_list_concat__fix_df1c6ef98c749f5c410a485b3d0d5d6851ad340d059d1012ed809a04a21a00a9.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/empty_list_concat.rs
 ---
-expression:
 [] ++ []
 ---
 --- <temp_file_path>

--- a/bin/tests/snapshots/empty_list_concat__lint_676800f4240e26802590a123362636e6d87461d7e091b87b44fb8b5959b31b1a.snap
+++ b/bin/tests/snapshots/empty_list_concat__lint_676800f4240e26802590a123362636e6d87461d7e091b87b44fb8b5959b31b1a.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/empty_list_concat.rs
 ---
-expression:
 [1 2 3] ++ []
 ---
 [W23] Warning: Unnecessary concatenation with empty list

--- a/bin/tests/snapshots/empty_list_concat__lint_676800f4240e26802590a123362636e6d87461d7e091b87b44fb8b5959b31b1a.snap
+++ b/bin/tests/snapshots/empty_list_concat__lint_676800f4240e26802590a123362636e6d87461d7e091b87b44fb8b5959b31b1a.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/empty_list_concat.rs
-expression: "\"[1 2 3] ++ []\""
+expression: snapshot
+---
+expression:
+[1 2 3] ++ []
 ---
 [W23] Warning: Unnecessary concatenation with empty list
    ╭─[<temp_file_path>:1:1]

--- a/bin/tests/snapshots/empty_list_concat__lint_676800f4240e26802590a123362636e6d87461d7e091b87b44fb8b5959b31b1a.snap
+++ b/bin/tests/snapshots/empty_list_concat__lint_676800f4240e26802590a123362636e6d87461d7e091b87b44fb8b5959b31b1a.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/empty_list_concat.rs
-expression: snapshot
 ---
 expression:
 [1 2 3] ++ []

--- a/bin/tests/snapshots/empty_list_concat__lint_6d44e9727e67c4d4d91c4b7abe2a2193f00467aabdd6230c1019702fdabe53bb.snap
+++ b/bin/tests/snapshots/empty_list_concat__lint_6d44e9727e67c4d4d91c4b7abe2a2193f00467aabdd6230c1019702fdabe53bb.snap
@@ -1,5 +1,7 @@
 ---
 source: bin/tests/empty_list_concat.rs
-expression: "\"[1 2] ++ [3 4]\""
+expression: snapshot
 ---
-
+expression:
+[1 2] ++ [3 4]
+---

--- a/bin/tests/snapshots/empty_list_concat__lint_6d44e9727e67c4d4d91c4b7abe2a2193f00467aabdd6230c1019702fdabe53bb.snap
+++ b/bin/tests/snapshots/empty_list_concat__lint_6d44e9727e67c4d4d91c4b7abe2a2193f00467aabdd6230c1019702fdabe53bb.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/empty_list_concat.rs
 ---
-expression:
 [1 2] ++ [3 4]
 ---

--- a/bin/tests/snapshots/empty_list_concat__lint_6d44e9727e67c4d4d91c4b7abe2a2193f00467aabdd6230c1019702fdabe53bb.snap
+++ b/bin/tests/snapshots/empty_list_concat__lint_6d44e9727e67c4d4d91c4b7abe2a2193f00467aabdd6230c1019702fdabe53bb.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/empty_list_concat.rs
-expression: snapshot
 ---
 expression:
 [1 2] ++ [3 4]

--- a/bin/tests/snapshots/empty_list_concat__lint_b13b2273654200cbc2315c6ceec0dbc9e4479628a5b7250418efeb5911e743b2.snap
+++ b/bin/tests/snapshots/empty_list_concat__lint_b13b2273654200cbc2315c6ceec0dbc9e4479628a5b7250418efeb5911e743b2.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/empty_list_concat.rs
-expression: snapshot
 ---
 expression:
 [] ++ [] ++ []

--- a/bin/tests/snapshots/empty_list_concat__lint_b13b2273654200cbc2315c6ceec0dbc9e4479628a5b7250418efeb5911e743b2.snap
+++ b/bin/tests/snapshots/empty_list_concat__lint_b13b2273654200cbc2315c6ceec0dbc9e4479628a5b7250418efeb5911e743b2.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/empty_list_concat.rs
 ---
-expression:
 [] ++ [] ++ []
 ---
 [W23] Warning: Unnecessary concatenation with empty list

--- a/bin/tests/snapshots/empty_list_concat__lint_b13b2273654200cbc2315c6ceec0dbc9e4479628a5b7250418efeb5911e743b2.snap
+++ b/bin/tests/snapshots/empty_list_concat__lint_b13b2273654200cbc2315c6ceec0dbc9e4479628a5b7250418efeb5911e743b2.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/empty_list_concat.rs
-expression: "\"[] ++ [] ++ []\""
+expression: snapshot
+---
+expression:
+[] ++ [] ++ []
 ---
 [W23] Warning: Unnecessary concatenation with empty list
    ╭─[<temp_file_path>:1:1]

--- a/bin/tests/snapshots/empty_list_concat__lint_b6d6b2d3b0ff0b3b842e3f816ced62ca22410c59471e767d80ea85a3f7fcc1ef.snap
+++ b/bin/tests/snapshots/empty_list_concat__lint_b6d6b2d3b0ff0b3b842e3f816ced62ca22410c59471e767d80ea85a3f7fcc1ef.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/empty_list_concat.rs
-expression: "\"[] ++ [1 2 3]\""
+expression: snapshot
+---
+expression:
+[] ++ [1 2 3]
 ---
 [W23] Warning: Unnecessary concatenation with empty list
    ╭─[<temp_file_path>:1:1]

--- a/bin/tests/snapshots/empty_list_concat__lint_b6d6b2d3b0ff0b3b842e3f816ced62ca22410c59471e767d80ea85a3f7fcc1ef.snap
+++ b/bin/tests/snapshots/empty_list_concat__lint_b6d6b2d3b0ff0b3b842e3f816ced62ca22410c59471e767d80ea85a3f7fcc1ef.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/empty_list_concat.rs
 ---
-expression:
 [] ++ [1 2 3]
 ---
 [W23] Warning: Unnecessary concatenation with empty list

--- a/bin/tests/snapshots/empty_list_concat__lint_b6d6b2d3b0ff0b3b842e3f816ced62ca22410c59471e767d80ea85a3f7fcc1ef.snap
+++ b/bin/tests/snapshots/empty_list_concat__lint_b6d6b2d3b0ff0b3b842e3f816ced62ca22410c59471e767d80ea85a3f7fcc1ef.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/empty_list_concat.rs
-expression: snapshot
 ---
 expression:
 [] ++ [1 2 3]

--- a/bin/tests/snapshots/empty_list_concat__lint_df1c6ef98c749f5c410a485b3d0d5d6851ad340d059d1012ed809a04a21a00a9.snap
+++ b/bin/tests/snapshots/empty_list_concat__lint_df1c6ef98c749f5c410a485b3d0d5d6851ad340d059d1012ed809a04a21a00a9.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/empty_list_concat.rs
-expression: snapshot
 ---
 expression:
 [] ++ []

--- a/bin/tests/snapshots/empty_list_concat__lint_df1c6ef98c749f5c410a485b3d0d5d6851ad340d059d1012ed809a04a21a00a9.snap
+++ b/bin/tests/snapshots/empty_list_concat__lint_df1c6ef98c749f5c410a485b3d0d5d6851ad340d059d1012ed809a04a21a00a9.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/empty_list_concat.rs
-expression: "\"[] ++ []\""
+expression: snapshot
+---
+expression:
+[] ++ []
 ---
 [W23] Warning: Unnecessary concatenation with empty list
    ╭─[<temp_file_path>:1:1]

--- a/bin/tests/snapshots/empty_list_concat__lint_df1c6ef98c749f5c410a485b3d0d5d6851ad340d059d1012ed809a04a21a00a9.snap
+++ b/bin/tests/snapshots/empty_list_concat__lint_df1c6ef98c749f5c410a485b3d0d5d6851ad340d059d1012ed809a04a21a00a9.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/empty_list_concat.rs
 ---
-expression:
 [] ++ []
 ---
 [W23] Warning: Unnecessary concatenation with empty list

--- a/bin/tests/snapshots/empty_pattern__fix_6f4e8d386aea545d7a5dbe6d074f9262f8899b97d157cda18f9a6d408ef1dee2.snap
+++ b/bin/tests/snapshots/empty_pattern__fix_6f4e8d386aea545d7a5dbe6d074f9262f8899b97d157cda18f9a6d408ef1dee2.snap
@@ -1,5 +1,7 @@
 ---
 source: bin/tests/empty_pattern.rs
-expression: "\"({ a, ... }: a)\""
+expression: snapshot
 ---
-
+expression:
+({ a, ... }: a)
+---

--- a/bin/tests/snapshots/empty_pattern__fix_6f4e8d386aea545d7a5dbe6d074f9262f8899b97d157cda18f9a6d408ef1dee2.snap
+++ b/bin/tests/snapshots/empty_pattern__fix_6f4e8d386aea545d7a5dbe6d074f9262f8899b97d157cda18f9a6d408ef1dee2.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/empty_pattern.rs
-expression: snapshot
 ---
 expression:
 ({ a, ... }: a)

--- a/bin/tests/snapshots/empty_pattern__fix_6f4e8d386aea545d7a5dbe6d074f9262f8899b97d157cda18f9a6d408ef1dee2.snap
+++ b/bin/tests/snapshots/empty_pattern__fix_6f4e8d386aea545d7a5dbe6d074f9262f8899b97d157cda18f9a6d408ef1dee2.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/empty_pattern.rs
 ---
-expression:
 ({ a, ... }: a)
 ---

--- a/bin/tests/snapshots/empty_pattern__fix_a0f60e09ffb31c58f803adaf8e3f854bb95fc3a4f6ac05072ee5f4f644a12141.snap
+++ b/bin/tests/snapshots/empty_pattern__fix_a0f60e09ffb31c58f803adaf8e3f854bb95fc3a4f6ac05072ee5f4f644a12141.snap
@@ -1,5 +1,7 @@
 ---
 source: bin/tests/empty_pattern.rs
-expression: "\"({ ... }: { imports = []; })\""
+expression: snapshot
 ---
-
+expression:
+({ ... }: { imports = []; })
+---

--- a/bin/tests/snapshots/empty_pattern__fix_a0f60e09ffb31c58f803adaf8e3f854bb95fc3a4f6ac05072ee5f4f644a12141.snap
+++ b/bin/tests/snapshots/empty_pattern__fix_a0f60e09ffb31c58f803adaf8e3f854bb95fc3a4f6ac05072ee5f4f644a12141.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/empty_pattern.rs
 ---
-expression:
 ({ ... }: { imports = []; })
 ---

--- a/bin/tests/snapshots/empty_pattern__fix_a0f60e09ffb31c58f803adaf8e3f854bb95fc3a4f6ac05072ee5f4f644a12141.snap
+++ b/bin/tests/snapshots/empty_pattern__fix_a0f60e09ffb31c58f803adaf8e3f854bb95fc3a4f6ac05072ee5f4f644a12141.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/empty_pattern.rs
-expression: snapshot
 ---
 expression:
 ({ ... }: { imports = []; })

--- a/bin/tests/snapshots/empty_pattern__fix_d126fd36c3561a6c02bd6635634d026132ac432cf96054241af194564f2d211a.snap
+++ b/bin/tests/snapshots/empty_pattern__fix_d126fd36c3561a6c02bd6635634d026132ac432cf96054241af194564f2d211a.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/empty_pattern.rs
 ---
-expression:
 ({ ... }: 42)
 ---
 --- <temp_file_path>

--- a/bin/tests/snapshots/empty_pattern__fix_d126fd36c3561a6c02bd6635634d026132ac432cf96054241af194564f2d211a.snap
+++ b/bin/tests/snapshots/empty_pattern__fix_d126fd36c3561a6c02bd6635634d026132ac432cf96054241af194564f2d211a.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/empty_pattern.rs
-expression: "\"({ ... }: 42)\""
+expression: snapshot
+---
+expression:
+({ ... }: 42)
 ---
 --- <temp_file_path>
 +++ <temp_file_path> [fixed]

--- a/bin/tests/snapshots/empty_pattern__fix_d126fd36c3561a6c02bd6635634d026132ac432cf96054241af194564f2d211a.snap
+++ b/bin/tests/snapshots/empty_pattern__fix_d126fd36c3561a6c02bd6635634d026132ac432cf96054241af194564f2d211a.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/empty_pattern.rs
-expression: snapshot
 ---
 expression:
 ({ ... }: 42)

--- a/bin/tests/snapshots/empty_pattern__fix_d258b2d28244a887c36cde36b8b3c30112c86c2090c39b776a1d03a64f503f40.snap
+++ b/bin/tests/snapshots/empty_pattern__fix_d258b2d28244a887c36cde36b8b3c30112c86c2090c39b776a1d03a64f503f40.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/empty_pattern.rs
-expression: snapshot
 ---
 expression:
 ({ ... } @ inputs: inputs)

--- a/bin/tests/snapshots/empty_pattern__fix_d258b2d28244a887c36cde36b8b3c30112c86c2090c39b776a1d03a64f503f40.snap
+++ b/bin/tests/snapshots/empty_pattern__fix_d258b2d28244a887c36cde36b8b3c30112c86c2090c39b776a1d03a64f503f40.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/empty_pattern.rs
 ---
-expression:
 ({ ... } @ inputs: inputs)
 ---
 --- <temp_file_path>

--- a/bin/tests/snapshots/empty_pattern__fix_d258b2d28244a887c36cde36b8b3c30112c86c2090c39b776a1d03a64f503f40.snap
+++ b/bin/tests/snapshots/empty_pattern__fix_d258b2d28244a887c36cde36b8b3c30112c86c2090c39b776a1d03a64f503f40.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/empty_pattern.rs
-expression: "\"({ ... } @ inputs: inputs)\""
+expression: snapshot
+---
+expression:
+({ ... } @ inputs: inputs)
 ---
 --- <temp_file_path>
 +++ <temp_file_path> [fixed]

--- a/bin/tests/snapshots/empty_pattern__lint_6f4e8d386aea545d7a5dbe6d074f9262f8899b97d157cda18f9a6d408ef1dee2.snap
+++ b/bin/tests/snapshots/empty_pattern__lint_6f4e8d386aea545d7a5dbe6d074f9262f8899b97d157cda18f9a6d408ef1dee2.snap
@@ -1,5 +1,7 @@
 ---
 source: bin/tests/empty_pattern.rs
-expression: "\"({ a, ... }: a)\""
+expression: snapshot
 ---
-
+expression:
+({ a, ... }: a)
+---

--- a/bin/tests/snapshots/empty_pattern__lint_6f4e8d386aea545d7a5dbe6d074f9262f8899b97d157cda18f9a6d408ef1dee2.snap
+++ b/bin/tests/snapshots/empty_pattern__lint_6f4e8d386aea545d7a5dbe6d074f9262f8899b97d157cda18f9a6d408ef1dee2.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/empty_pattern.rs
-expression: snapshot
 ---
 expression:
 ({ a, ... }: a)

--- a/bin/tests/snapshots/empty_pattern__lint_6f4e8d386aea545d7a5dbe6d074f9262f8899b97d157cda18f9a6d408ef1dee2.snap
+++ b/bin/tests/snapshots/empty_pattern__lint_6f4e8d386aea545d7a5dbe6d074f9262f8899b97d157cda18f9a6d408ef1dee2.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/empty_pattern.rs
 ---
-expression:
 ({ a, ... }: a)
 ---

--- a/bin/tests/snapshots/empty_pattern__lint_a0f60e09ffb31c58f803adaf8e3f854bb95fc3a4f6ac05072ee5f4f644a12141.snap
+++ b/bin/tests/snapshots/empty_pattern__lint_a0f60e09ffb31c58f803adaf8e3f854bb95fc3a4f6ac05072ee5f4f644a12141.snap
@@ -1,5 +1,7 @@
 ---
 source: bin/tests/empty_pattern.rs
-expression: "\"({ ... }: { imports = []; })\""
+expression: snapshot
 ---
-
+expression:
+({ ... }: { imports = []; })
+---

--- a/bin/tests/snapshots/empty_pattern__lint_a0f60e09ffb31c58f803adaf8e3f854bb95fc3a4f6ac05072ee5f4f644a12141.snap
+++ b/bin/tests/snapshots/empty_pattern__lint_a0f60e09ffb31c58f803adaf8e3f854bb95fc3a4f6ac05072ee5f4f644a12141.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/empty_pattern.rs
 ---
-expression:
 ({ ... }: { imports = []; })
 ---

--- a/bin/tests/snapshots/empty_pattern__lint_a0f60e09ffb31c58f803adaf8e3f854bb95fc3a4f6ac05072ee5f4f644a12141.snap
+++ b/bin/tests/snapshots/empty_pattern__lint_a0f60e09ffb31c58f803adaf8e3f854bb95fc3a4f6ac05072ee5f4f644a12141.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/empty_pattern.rs
-expression: snapshot
 ---
 expression:
 ({ ... }: { imports = []; })

--- a/bin/tests/snapshots/empty_pattern__lint_d126fd36c3561a6c02bd6635634d026132ac432cf96054241af194564f2d211a.snap
+++ b/bin/tests/snapshots/empty_pattern__lint_d126fd36c3561a6c02bd6635634d026132ac432cf96054241af194564f2d211a.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/empty_pattern.rs
-expression: "\"({ ... }: 42)\""
+expression: snapshot
+---
+expression:
+({ ... }: 42)
 ---
 [W10] Warning: Found empty pattern in function argument
    ╭─[<temp_file_path>:1:2]

--- a/bin/tests/snapshots/empty_pattern__lint_d126fd36c3561a6c02bd6635634d026132ac432cf96054241af194564f2d211a.snap
+++ b/bin/tests/snapshots/empty_pattern__lint_d126fd36c3561a6c02bd6635634d026132ac432cf96054241af194564f2d211a.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/empty_pattern.rs
 ---
-expression:
 ({ ... }: 42)
 ---
 [W10] Warning: Found empty pattern in function argument

--- a/bin/tests/snapshots/empty_pattern__lint_d126fd36c3561a6c02bd6635634d026132ac432cf96054241af194564f2d211a.snap
+++ b/bin/tests/snapshots/empty_pattern__lint_d126fd36c3561a6c02bd6635634d026132ac432cf96054241af194564f2d211a.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/empty_pattern.rs
-expression: snapshot
 ---
 expression:
 ({ ... }: 42)

--- a/bin/tests/snapshots/empty_pattern__lint_d258b2d28244a887c36cde36b8b3c30112c86c2090c39b776a1d03a64f503f40.snap
+++ b/bin/tests/snapshots/empty_pattern__lint_d258b2d28244a887c36cde36b8b3c30112c86c2090c39b776a1d03a64f503f40.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/empty_pattern.rs
-expression: snapshot
 ---
 expression:
 ({ ... } @ inputs: inputs)

--- a/bin/tests/snapshots/empty_pattern__lint_d258b2d28244a887c36cde36b8b3c30112c86c2090c39b776a1d03a64f503f40.snap
+++ b/bin/tests/snapshots/empty_pattern__lint_d258b2d28244a887c36cde36b8b3c30112c86c2090c39b776a1d03a64f503f40.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/empty_pattern.rs
-expression: "\"({ ... } @ inputs: inputs)\""
+expression: snapshot
+---
+expression:
+({ ... } @ inputs: inputs)
 ---
 [W11] Warning: Found redundant pattern bind in function argument
    ╭─[<temp_file_path>:1:2]

--- a/bin/tests/snapshots/empty_pattern__lint_d258b2d28244a887c36cde36b8b3c30112c86c2090c39b776a1d03a64f503f40.snap
+++ b/bin/tests/snapshots/empty_pattern__lint_d258b2d28244a887c36cde36b8b3c30112c86c2090c39b776a1d03a64f503f40.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/empty_pattern.rs
 ---
-expression:
 ({ ... } @ inputs: inputs)
 ---
 [W11] Warning: Found redundant pattern bind in function argument

--- a/bin/tests/snapshots/eta_reduction__fix_1753a4ee5edee65b9e4cbd0efbbfb45be4abfe4c556a183b4e56dd3e2ebb200e.snap
+++ b/bin/tests/snapshots/eta_reduction__fix_1753a4ee5edee65b9e4cbd0efbbfb45be4abfe4c556a183b4e56dd3e2ebb200e.snap
@@ -1,5 +1,7 @@
 ---
 source: bin/tests/eta_reduction.rs
-expression: "\"let f = { double = x: x *2; val = 2; }; in map (f: {inherit f;}.double f.val) [ f ]\""
+expression: snapshot
 ---
-
+expression:
+let f = { double = x: x *2; val = 2; }; in map (f: {inherit f;}.double f.val) [ f ]
+---

--- a/bin/tests/snapshots/eta_reduction__fix_1753a4ee5edee65b9e4cbd0efbbfb45be4abfe4c556a183b4e56dd3e2ebb200e.snap
+++ b/bin/tests/snapshots/eta_reduction__fix_1753a4ee5edee65b9e4cbd0efbbfb45be4abfe4c556a183b4e56dd3e2ebb200e.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/eta_reduction.rs
-expression: snapshot
 ---
 expression:
 let f = { double = x: x *2; val = 2; }; in map (f: {inherit f;}.double f.val) [ f ]

--- a/bin/tests/snapshots/eta_reduction__fix_1753a4ee5edee65b9e4cbd0efbbfb45be4abfe4c556a183b4e56dd3e2ebb200e.snap
+++ b/bin/tests/snapshots/eta_reduction__fix_1753a4ee5edee65b9e4cbd0efbbfb45be4abfe4c556a183b4e56dd3e2ebb200e.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/eta_reduction.rs
 ---
-expression:
 let f = { double = x: x *2; val = 2; }; in map (f: {inherit f;}.double f.val) [ f ]
 ---

--- a/bin/tests/snapshots/eta_reduction__fix_2af9e5afbc8ddbb1cdd61c38fa47661f18ef38e477f843fa6eb8fe3f11d76462.snap
+++ b/bin/tests/snapshots/eta_reduction__fix_2af9e5afbc8ddbb1cdd61c38fa47661f18ef38e477f843fa6eb8fe3f11d76462.snap
@@ -1,5 +1,7 @@
 ---
 source: bin/tests/eta_reduction.rs
-expression: "\"let f = { double = x: x *2; val = 2; }; in map (f: f.double f.val) [ f ]\""
+expression: snapshot
 ---
-
+expression:
+let f = { double = x: x *2; val = 2; }; in map (f: f.double f.val) [ f ]
+---

--- a/bin/tests/snapshots/eta_reduction__fix_2af9e5afbc8ddbb1cdd61c38fa47661f18ef38e477f843fa6eb8fe3f11d76462.snap
+++ b/bin/tests/snapshots/eta_reduction__fix_2af9e5afbc8ddbb1cdd61c38fa47661f18ef38e477f843fa6eb8fe3f11d76462.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/eta_reduction.rs
 ---
-expression:
 let f = { double = x: x *2; val = 2; }; in map (f: f.double f.val) [ f ]
 ---

--- a/bin/tests/snapshots/eta_reduction__fix_2af9e5afbc8ddbb1cdd61c38fa47661f18ef38e477f843fa6eb8fe3f11d76462.snap
+++ b/bin/tests/snapshots/eta_reduction__fix_2af9e5afbc8ddbb1cdd61c38fa47661f18ef38e477f843fa6eb8fe3f11d76462.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/eta_reduction.rs
-expression: snapshot
 ---
 expression:
 let f = { double = x: x *2; val = 2; }; in map (f: f.double f.val) [ f ]

--- a/bin/tests/snapshots/eta_reduction__fix_371c868dbc9581a6fc41c7085146a422829b37c0e7d4ec0cf2b2d48d2e116b71.snap
+++ b/bin/tests/snapshots/eta_reduction__fix_371c868dbc9581a6fc41c7085146a422829b37c0e7d4ec0cf2b2d48d2e116b71.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/eta_reduction.rs
-expression: snapshot
 ---
 expression:
 let double = x: x * 2; in map (x: double x) [1 2 3]

--- a/bin/tests/snapshots/eta_reduction__fix_371c868dbc9581a6fc41c7085146a422829b37c0e7d4ec0cf2b2d48d2e116b71.snap
+++ b/bin/tests/snapshots/eta_reduction__fix_371c868dbc9581a6fc41c7085146a422829b37c0e7d4ec0cf2b2d48d2e116b71.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/eta_reduction.rs
-expression: "\"let double = x: x * 2; in map (x: double x) [1 2 3]\""
+expression: snapshot
+---
+expression:
+let double = x: x * 2; in map (x: double x) [1 2 3]
 ---
 --- <temp_file_path>
 +++ <temp_file_path> [fixed]

--- a/bin/tests/snapshots/eta_reduction__fix_371c868dbc9581a6fc41c7085146a422829b37c0e7d4ec0cf2b2d48d2e116b71.snap
+++ b/bin/tests/snapshots/eta_reduction__fix_371c868dbc9581a6fc41c7085146a422829b37c0e7d4ec0cf2b2d48d2e116b71.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/eta_reduction.rs
 ---
-expression:
 let double = x: x * 2; in map (x: double x) [1 2 3]
 ---
 --- <temp_file_path>

--- a/bin/tests/snapshots/eta_reduction__fix_860ea9e8412515330162460cc2e1b25bc90c61c53b6c5bd37981257482ae7254.snap
+++ b/bin/tests/snapshots/eta_reduction__fix_860ea9e8412515330162460cc2e1b25bc90c61c53b6c5bd37981257482ae7254.snap
@@ -1,5 +1,7 @@
 ---
 source: bin/tests/eta_reduction.rs
-expression: "\"map (x: builtins.div 3 x) [1 2 3]\""
+expression: snapshot
 ---
-
+expression:
+map (x: builtins.div 3 x) [1 2 3]
+---

--- a/bin/tests/snapshots/eta_reduction__fix_860ea9e8412515330162460cc2e1b25bc90c61c53b6c5bd37981257482ae7254.snap
+++ b/bin/tests/snapshots/eta_reduction__fix_860ea9e8412515330162460cc2e1b25bc90c61c53b6c5bd37981257482ae7254.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/eta_reduction.rs
 ---
-expression:
 map (x: builtins.div 3 x) [1 2 3]
 ---

--- a/bin/tests/snapshots/eta_reduction__fix_860ea9e8412515330162460cc2e1b25bc90c61c53b6c5bd37981257482ae7254.snap
+++ b/bin/tests/snapshots/eta_reduction__fix_860ea9e8412515330162460cc2e1b25bc90c61c53b6c5bd37981257482ae7254.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/eta_reduction.rs
-expression: snapshot
 ---
 expression:
 map (x: builtins.div 3 x) [1 2 3]

--- a/bin/tests/snapshots/eta_reduction__lint_1753a4ee5edee65b9e4cbd0efbbfb45be4abfe4c556a183b4e56dd3e2ebb200e.snap
+++ b/bin/tests/snapshots/eta_reduction__lint_1753a4ee5edee65b9e4cbd0efbbfb45be4abfe4c556a183b4e56dd3e2ebb200e.snap
@@ -1,5 +1,7 @@
 ---
 source: bin/tests/eta_reduction.rs
-expression: "\"let f = { double = x: x *2; val = 2; }; in map (f: {inherit f;}.double f.val) [ f ]\""
+expression: snapshot
 ---
-
+expression:
+let f = { double = x: x *2; val = 2; }; in map (f: {inherit f;}.double f.val) [ f ]
+---

--- a/bin/tests/snapshots/eta_reduction__lint_1753a4ee5edee65b9e4cbd0efbbfb45be4abfe4c556a183b4e56dd3e2ebb200e.snap
+++ b/bin/tests/snapshots/eta_reduction__lint_1753a4ee5edee65b9e4cbd0efbbfb45be4abfe4c556a183b4e56dd3e2ebb200e.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/eta_reduction.rs
-expression: snapshot
 ---
 expression:
 let f = { double = x: x *2; val = 2; }; in map (f: {inherit f;}.double f.val) [ f ]

--- a/bin/tests/snapshots/eta_reduction__lint_1753a4ee5edee65b9e4cbd0efbbfb45be4abfe4c556a183b4e56dd3e2ebb200e.snap
+++ b/bin/tests/snapshots/eta_reduction__lint_1753a4ee5edee65b9e4cbd0efbbfb45be4abfe4c556a183b4e56dd3e2ebb200e.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/eta_reduction.rs
 ---
-expression:
 let f = { double = x: x *2; val = 2; }; in map (f: {inherit f;}.double f.val) [ f ]
 ---

--- a/bin/tests/snapshots/eta_reduction__lint_2af9e5afbc8ddbb1cdd61c38fa47661f18ef38e477f843fa6eb8fe3f11d76462.snap
+++ b/bin/tests/snapshots/eta_reduction__lint_2af9e5afbc8ddbb1cdd61c38fa47661f18ef38e477f843fa6eb8fe3f11d76462.snap
@@ -1,5 +1,7 @@
 ---
 source: bin/tests/eta_reduction.rs
-expression: "\"let f = { double = x: x *2; val = 2; }; in map (f: f.double f.val) [ f ]\""
+expression: snapshot
 ---
-
+expression:
+let f = { double = x: x *2; val = 2; }; in map (f: f.double f.val) [ f ]
+---

--- a/bin/tests/snapshots/eta_reduction__lint_2af9e5afbc8ddbb1cdd61c38fa47661f18ef38e477f843fa6eb8fe3f11d76462.snap
+++ b/bin/tests/snapshots/eta_reduction__lint_2af9e5afbc8ddbb1cdd61c38fa47661f18ef38e477f843fa6eb8fe3f11d76462.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/eta_reduction.rs
 ---
-expression:
 let f = { double = x: x *2; val = 2; }; in map (f: f.double f.val) [ f ]
 ---

--- a/bin/tests/snapshots/eta_reduction__lint_2af9e5afbc8ddbb1cdd61c38fa47661f18ef38e477f843fa6eb8fe3f11d76462.snap
+++ b/bin/tests/snapshots/eta_reduction__lint_2af9e5afbc8ddbb1cdd61c38fa47661f18ef38e477f843fa6eb8fe3f11d76462.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/eta_reduction.rs
-expression: snapshot
 ---
 expression:
 let f = { double = x: x *2; val = 2; }; in map (f: f.double f.val) [ f ]

--- a/bin/tests/snapshots/eta_reduction__lint_371c868dbc9581a6fc41c7085146a422829b37c0e7d4ec0cf2b2d48d2e116b71.snap
+++ b/bin/tests/snapshots/eta_reduction__lint_371c868dbc9581a6fc41c7085146a422829b37c0e7d4ec0cf2b2d48d2e116b71.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/eta_reduction.rs
-expression: snapshot
 ---
 expression:
 let double = x: x * 2; in map (x: double x) [1 2 3]

--- a/bin/tests/snapshots/eta_reduction__lint_371c868dbc9581a6fc41c7085146a422829b37c0e7d4ec0cf2b2d48d2e116b71.snap
+++ b/bin/tests/snapshots/eta_reduction__lint_371c868dbc9581a6fc41c7085146a422829b37c0e7d4ec0cf2b2d48d2e116b71.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/eta_reduction.rs
 ---
-expression:
 let double = x: x * 2; in map (x: double x) [1 2 3]
 ---
 [W07] Warning: This function expression is eta reducible

--- a/bin/tests/snapshots/eta_reduction__lint_371c868dbc9581a6fc41c7085146a422829b37c0e7d4ec0cf2b2d48d2e116b71.snap
+++ b/bin/tests/snapshots/eta_reduction__lint_371c868dbc9581a6fc41c7085146a422829b37c0e7d4ec0cf2b2d48d2e116b71.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/eta_reduction.rs
-expression: "\"let double = x: x * 2; in map (x: double x) [1 2 3]\""
+expression: snapshot
+---
+expression:
+let double = x: x * 2; in map (x: double x) [1 2 3]
 ---
 [W07] Warning: This function expression is eta reducible
    ╭─[<temp_file_path>:1:32]

--- a/bin/tests/snapshots/eta_reduction__lint_860ea9e8412515330162460cc2e1b25bc90c61c53b6c5bd37981257482ae7254.snap
+++ b/bin/tests/snapshots/eta_reduction__lint_860ea9e8412515330162460cc2e1b25bc90c61c53b6c5bd37981257482ae7254.snap
@@ -1,5 +1,7 @@
 ---
 source: bin/tests/eta_reduction.rs
-expression: "\"map (x: builtins.div 3 x) [1 2 3]\""
+expression: snapshot
 ---
-
+expression:
+map (x: builtins.div 3 x) [1 2 3]
+---

--- a/bin/tests/snapshots/eta_reduction__lint_860ea9e8412515330162460cc2e1b25bc90c61c53b6c5bd37981257482ae7254.snap
+++ b/bin/tests/snapshots/eta_reduction__lint_860ea9e8412515330162460cc2e1b25bc90c61c53b6c5bd37981257482ae7254.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/eta_reduction.rs
 ---
-expression:
 map (x: builtins.div 3 x) [1 2 3]
 ---

--- a/bin/tests/snapshots/eta_reduction__lint_860ea9e8412515330162460cc2e1b25bc90c61c53b6c5bd37981257482ae7254.snap
+++ b/bin/tests/snapshots/eta_reduction__lint_860ea9e8412515330162460cc2e1b25bc90c61c53b6c5bd37981257482ae7254.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/eta_reduction.rs
-expression: snapshot
 ---
 expression:
 map (x: builtins.div 3 x) [1 2 3]

--- a/bin/tests/snapshots/legacy_let_syntax__fix_7b38199c6c6f7f991caca355bdf9d4ebb9a8efc7745407121fc6b5702dd94e74.snap
+++ b/bin/tests/snapshots/legacy_let_syntax__fix_7b38199c6c6f7f991caca355bdf9d4ebb9a8efc7745407121fc6b5702dd94e74.snap
@@ -1,6 +1,14 @@
 ---
 source: bin/tests/legacy_let_syntax.rs
-expression: "\"let {\\n  body = x + y;\\n  x = \\\"hello,\\\";\\n  y = \\\" world!\\\";\\n}\\n\""
+expression: snapshot
+---
+expression:
+let {
+  body = x + y;
+  x = "hello,";
+  y = " world!";
+}
+
 ---
 --- <temp_file_path>
 +++ <temp_file_path> [fixed]

--- a/bin/tests/snapshots/legacy_let_syntax__fix_7b38199c6c6f7f991caca355bdf9d4ebb9a8efc7745407121fc6b5702dd94e74.snap
+++ b/bin/tests/snapshots/legacy_let_syntax__fix_7b38199c6c6f7f991caca355bdf9d4ebb9a8efc7745407121fc6b5702dd94e74.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/legacy_let_syntax.rs
-expression: snapshot
 ---
 expression:
 let {

--- a/bin/tests/snapshots/legacy_let_syntax__fix_7b38199c6c6f7f991caca355bdf9d4ebb9a8efc7745407121fc6b5702dd94e74.snap
+++ b/bin/tests/snapshots/legacy_let_syntax__fix_7b38199c6c6f7f991caca355bdf9d4ebb9a8efc7745407121fc6b5702dd94e74.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/legacy_let_syntax.rs
 ---
-expression:
 let {
   body = x + y;
   x = "hello,";

--- a/bin/tests/snapshots/legacy_let_syntax__lint_7b38199c6c6f7f991caca355bdf9d4ebb9a8efc7745407121fc6b5702dd94e74.snap
+++ b/bin/tests/snapshots/legacy_let_syntax__lint_7b38199c6c6f7f991caca355bdf9d4ebb9a8efc7745407121fc6b5702dd94e74.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/legacy_let_syntax.rs
-expression: snapshot
 ---
 expression:
 let {

--- a/bin/tests/snapshots/legacy_let_syntax__lint_7b38199c6c6f7f991caca355bdf9d4ebb9a8efc7745407121fc6b5702dd94e74.snap
+++ b/bin/tests/snapshots/legacy_let_syntax__lint_7b38199c6c6f7f991caca355bdf9d4ebb9a8efc7745407121fc6b5702dd94e74.snap
@@ -1,6 +1,14 @@
 ---
 source: bin/tests/legacy_let_syntax.rs
-expression: "\"let {\\n  body = x + y;\\n  x = \\\"hello,\\\";\\n  y = \\\" world!\\\";\\n}\\n\""
+expression: snapshot
+---
+expression:
+let {
+  body = x + y;
+  x = "hello,";
+  y = " world!";
+}
+
 ---
 [W05] Warning: Using undocumented `let` syntax
    ╭─[<temp_file_path>:1:1]

--- a/bin/tests/snapshots/legacy_let_syntax__lint_7b38199c6c6f7f991caca355bdf9d4ebb9a8efc7745407121fc6b5702dd94e74.snap
+++ b/bin/tests/snapshots/legacy_let_syntax__lint_7b38199c6c6f7f991caca355bdf9d4ebb9a8efc7745407121fc6b5702dd94e74.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/legacy_let_syntax.rs
 ---
-expression:
 let {
   body = x + y;
   x = "hello,";

--- a/bin/tests/snapshots/manual_inherit__fix_287b90d387af9044b772153bd95b398106d6e004717c9530e9aa547ef39a1f20.snap
+++ b/bin/tests/snapshots/manual_inherit__fix_287b90d387af9044b772153bd95b398106d6e004717c9530e9aa547ef39a1f20.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/manual_inherit.rs
 ---
-expression:
 let y = 2; in { x.y = y; }
 ---

--- a/bin/tests/snapshots/manual_inherit__fix_287b90d387af9044b772153bd95b398106d6e004717c9530e9aa547ef39a1f20.snap
+++ b/bin/tests/snapshots/manual_inherit__fix_287b90d387af9044b772153bd95b398106d6e004717c9530e9aa547ef39a1f20.snap
@@ -1,5 +1,7 @@
 ---
 source: bin/tests/manual_inherit.rs
-expression: "\"let y = 2; in { x.y = y; }\""
+expression: snapshot
 ---
-
+expression:
+let y = 2; in { x.y = y; }
+---

--- a/bin/tests/snapshots/manual_inherit__fix_287b90d387af9044b772153bd95b398106d6e004717c9530e9aa547ef39a1f20.snap
+++ b/bin/tests/snapshots/manual_inherit__fix_287b90d387af9044b772153bd95b398106d6e004717c9530e9aa547ef39a1f20.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/manual_inherit.rs
-expression: snapshot
 ---
 expression:
 let y = 2; in { x.y = y; }

--- a/bin/tests/snapshots/manual_inherit__fix_2a92c1cb560d2d727373fb3ad10da2b17cf57a13421fc72f9847d8d25bf8099d.snap
+++ b/bin/tests/snapshots/manual_inherit__fix_2a92c1cb560d2d727373fb3ad10da2b17cf57a13421fc72f9847d8d25bf8099d.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/manual_inherit.rs
-expression: snapshot
 ---
 expression:
 let a = 2; in { a = a; }

--- a/bin/tests/snapshots/manual_inherit__fix_2a92c1cb560d2d727373fb3ad10da2b17cf57a13421fc72f9847d8d25bf8099d.snap
+++ b/bin/tests/snapshots/manual_inherit__fix_2a92c1cb560d2d727373fb3ad10da2b17cf57a13421fc72f9847d8d25bf8099d.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/manual_inherit.rs
-expression: "\"let a = 2; in { a = a; }\""
+expression: snapshot
+---
+expression:
+let a = 2; in { a = a; }
 ---
 --- <temp_file_path>
 +++ <temp_file_path> [fixed]

--- a/bin/tests/snapshots/manual_inherit__fix_2a92c1cb560d2d727373fb3ad10da2b17cf57a13421fc72f9847d8d25bf8099d.snap
+++ b/bin/tests/snapshots/manual_inherit__fix_2a92c1cb560d2d727373fb3ad10da2b17cf57a13421fc72f9847d8d25bf8099d.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/manual_inherit.rs
 ---
-expression:
 let a = 2; in { a = a; }
 ---
 --- <temp_file_path>

--- a/bin/tests/snapshots/manual_inherit__lint_287b90d387af9044b772153bd95b398106d6e004717c9530e9aa547ef39a1f20.snap
+++ b/bin/tests/snapshots/manual_inherit__lint_287b90d387af9044b772153bd95b398106d6e004717c9530e9aa547ef39a1f20.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/manual_inherit.rs
 ---
-expression:
 let y = 2; in { x.y = y; }
 ---

--- a/bin/tests/snapshots/manual_inherit__lint_287b90d387af9044b772153bd95b398106d6e004717c9530e9aa547ef39a1f20.snap
+++ b/bin/tests/snapshots/manual_inherit__lint_287b90d387af9044b772153bd95b398106d6e004717c9530e9aa547ef39a1f20.snap
@@ -1,5 +1,7 @@
 ---
 source: bin/tests/manual_inherit.rs
-expression: "\"let y = 2; in { x.y = y; }\""
+expression: snapshot
 ---
-
+expression:
+let y = 2; in { x.y = y; }
+---

--- a/bin/tests/snapshots/manual_inherit__lint_287b90d387af9044b772153bd95b398106d6e004717c9530e9aa547ef39a1f20.snap
+++ b/bin/tests/snapshots/manual_inherit__lint_287b90d387af9044b772153bd95b398106d6e004717c9530e9aa547ef39a1f20.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/manual_inherit.rs
-expression: snapshot
 ---
 expression:
 let y = 2; in { x.y = y; }

--- a/bin/tests/snapshots/manual_inherit__lint_2a92c1cb560d2d727373fb3ad10da2b17cf57a13421fc72f9847d8d25bf8099d.snap
+++ b/bin/tests/snapshots/manual_inherit__lint_2a92c1cb560d2d727373fb3ad10da2b17cf57a13421fc72f9847d8d25bf8099d.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/manual_inherit.rs
 ---
-expression:
 let a = 2; in { a = a; }
 ---
 [W03] Warning: Assignment instead of inherit

--- a/bin/tests/snapshots/manual_inherit__lint_2a92c1cb560d2d727373fb3ad10da2b17cf57a13421fc72f9847d8d25bf8099d.snap
+++ b/bin/tests/snapshots/manual_inherit__lint_2a92c1cb560d2d727373fb3ad10da2b17cf57a13421fc72f9847d8d25bf8099d.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/manual_inherit.rs
-expression: "\"let a = 2; in { a = a; }\""
+expression: snapshot
+---
+expression:
+let a = 2; in { a = a; }
 ---
 [W03] Warning: Assignment instead of inherit
    ╭─[<temp_file_path>:1:17]

--- a/bin/tests/snapshots/manual_inherit__lint_2a92c1cb560d2d727373fb3ad10da2b17cf57a13421fc72f9847d8d25bf8099d.snap
+++ b/bin/tests/snapshots/manual_inherit__lint_2a92c1cb560d2d727373fb3ad10da2b17cf57a13421fc72f9847d8d25bf8099d.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/manual_inherit.rs
-expression: snapshot
 ---
 expression:
 let a = 2; in { a = a; }

--- a/bin/tests/snapshots/manual_inherit_from__fix_a1dd16d76c1e3a76c0da83256a89a945dccc51f490fd14269722a647f8cda9ad.snap
+++ b/bin/tests/snapshots/manual_inherit_from__fix_a1dd16d76c1e3a76c0da83256a89a945dccc51f490fd14269722a647f8cda9ad.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/manual_inherit_from.rs
 ---
-expression:
 let a.b = 2; in { b = a.c; }
 ---

--- a/bin/tests/snapshots/manual_inherit_from__fix_a1dd16d76c1e3a76c0da83256a89a945dccc51f490fd14269722a647f8cda9ad.snap
+++ b/bin/tests/snapshots/manual_inherit_from__fix_a1dd16d76c1e3a76c0da83256a89a945dccc51f490fd14269722a647f8cda9ad.snap
@@ -1,5 +1,7 @@
 ---
 source: bin/tests/manual_inherit_from.rs
-expression: "\"let a.b = 2; in { b = a.c; }\""
+expression: snapshot
 ---
-
+expression:
+let a.b = 2; in { b = a.c; }
+---

--- a/bin/tests/snapshots/manual_inherit_from__fix_a1dd16d76c1e3a76c0da83256a89a945dccc51f490fd14269722a647f8cda9ad.snap
+++ b/bin/tests/snapshots/manual_inherit_from__fix_a1dd16d76c1e3a76c0da83256a89a945dccc51f490fd14269722a647f8cda9ad.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/manual_inherit_from.rs
-expression: snapshot
 ---
 expression:
 let a.b = 2; in { b = a.c; }

--- a/bin/tests/snapshots/manual_inherit_from__fix_b169f7b47a1e5a5efcfc052399cd20e9c361b5dcdaeca5c91d7719a2b9561712.snap
+++ b/bin/tests/snapshots/manual_inherit_from__fix_b169f7b47a1e5a5efcfc052399cd20e9c361b5dcdaeca5c91d7719a2b9561712.snap
@@ -1,5 +1,7 @@
 ---
 source: bin/tests/manual_inherit_from.rs
-expression: "\"let foo = { }; in { x = foo.x or false; }\""
+expression: snapshot
 ---
-
+expression:
+let foo = { }; in { x = foo.x or false; }
+---

--- a/bin/tests/snapshots/manual_inherit_from__fix_b169f7b47a1e5a5efcfc052399cd20e9c361b5dcdaeca5c91d7719a2b9561712.snap
+++ b/bin/tests/snapshots/manual_inherit_from__fix_b169f7b47a1e5a5efcfc052399cd20e9c361b5dcdaeca5c91d7719a2b9561712.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/manual_inherit_from.rs
 ---
-expression:
 let foo = { }; in { x = foo.x or false; }
 ---

--- a/bin/tests/snapshots/manual_inherit_from__fix_b169f7b47a1e5a5efcfc052399cd20e9c361b5dcdaeca5c91d7719a2b9561712.snap
+++ b/bin/tests/snapshots/manual_inherit_from__fix_b169f7b47a1e5a5efcfc052399cd20e9c361b5dcdaeca5c91d7719a2b9561712.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/manual_inherit_from.rs
-expression: snapshot
 ---
 expression:
 let foo = { }; in { x = foo.x or false; }

--- a/bin/tests/snapshots/manual_inherit_from__fix_d185f6bcc057384cb2f1ae3abb567fd17572eaaa2c3209abd0f527f3fe7e26a1.snap
+++ b/bin/tests/snapshots/manual_inherit_from__fix_d185f6bcc057384cb2f1ae3abb567fd17572eaaa2c3209abd0f527f3fe7e26a1.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/manual_inherit_from.rs
 ---
-expression:
 let a.b = 2; in { b = a.b; }
 ---
 --- <temp_file_path>

--- a/bin/tests/snapshots/manual_inherit_from__fix_d185f6bcc057384cb2f1ae3abb567fd17572eaaa2c3209abd0f527f3fe7e26a1.snap
+++ b/bin/tests/snapshots/manual_inherit_from__fix_d185f6bcc057384cb2f1ae3abb567fd17572eaaa2c3209abd0f527f3fe7e26a1.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/manual_inherit_from.rs
-expression: snapshot
 ---
 expression:
 let a.b = 2; in { b = a.b; }

--- a/bin/tests/snapshots/manual_inherit_from__fix_d185f6bcc057384cb2f1ae3abb567fd17572eaaa2c3209abd0f527f3fe7e26a1.snap
+++ b/bin/tests/snapshots/manual_inherit_from__fix_d185f6bcc057384cb2f1ae3abb567fd17572eaaa2c3209abd0f527f3fe7e26a1.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/manual_inherit_from.rs
-expression: "\"let a.b = 2; in { b = a.b; }\""
+expression: snapshot
+---
+expression:
+let a.b = 2; in { b = a.b; }
 ---
 --- <temp_file_path>
 +++ <temp_file_path> [fixed]

--- a/bin/tests/snapshots/manual_inherit_from__fix_fddffc3b779f8727d3ce7613925d3d3df2bc6cc9a30841fe104e26219ed72187.snap
+++ b/bin/tests/snapshots/manual_inherit_from__fix_fddffc3b779f8727d3ce7613925d3d3df2bc6cc9a30841fe104e26219ed72187.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/manual_inherit_from.rs
 ---
-expression:
 let a.b = 2; in { c = a.c; }
 ---
 --- <temp_file_path>

--- a/bin/tests/snapshots/manual_inherit_from__fix_fddffc3b779f8727d3ce7613925d3d3df2bc6cc9a30841fe104e26219ed72187.snap
+++ b/bin/tests/snapshots/manual_inherit_from__fix_fddffc3b779f8727d3ce7613925d3d3df2bc6cc9a30841fe104e26219ed72187.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/manual_inherit_from.rs
-expression: "\"let a.b = 2; in { c = a.c; }\""
+expression: snapshot
+---
+expression:
+let a.b = 2; in { c = a.c; }
 ---
 --- <temp_file_path>
 +++ <temp_file_path> [fixed]

--- a/bin/tests/snapshots/manual_inherit_from__fix_fddffc3b779f8727d3ce7613925d3d3df2bc6cc9a30841fe104e26219ed72187.snap
+++ b/bin/tests/snapshots/manual_inherit_from__fix_fddffc3b779f8727d3ce7613925d3d3df2bc6cc9a30841fe104e26219ed72187.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/manual_inherit_from.rs
-expression: snapshot
 ---
 expression:
 let a.b = 2; in { c = a.c; }

--- a/bin/tests/snapshots/manual_inherit_from__lint_a1dd16d76c1e3a76c0da83256a89a945dccc51f490fd14269722a647f8cda9ad.snap
+++ b/bin/tests/snapshots/manual_inherit_from__lint_a1dd16d76c1e3a76c0da83256a89a945dccc51f490fd14269722a647f8cda9ad.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/manual_inherit_from.rs
 ---
-expression:
 let a.b = 2; in { b = a.c; }
 ---

--- a/bin/tests/snapshots/manual_inherit_from__lint_a1dd16d76c1e3a76c0da83256a89a945dccc51f490fd14269722a647f8cda9ad.snap
+++ b/bin/tests/snapshots/manual_inherit_from__lint_a1dd16d76c1e3a76c0da83256a89a945dccc51f490fd14269722a647f8cda9ad.snap
@@ -1,5 +1,7 @@
 ---
 source: bin/tests/manual_inherit_from.rs
-expression: "\"let a.b = 2; in { b = a.c; }\""
+expression: snapshot
 ---
-
+expression:
+let a.b = 2; in { b = a.c; }
+---

--- a/bin/tests/snapshots/manual_inherit_from__lint_a1dd16d76c1e3a76c0da83256a89a945dccc51f490fd14269722a647f8cda9ad.snap
+++ b/bin/tests/snapshots/manual_inherit_from__lint_a1dd16d76c1e3a76c0da83256a89a945dccc51f490fd14269722a647f8cda9ad.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/manual_inherit_from.rs
-expression: snapshot
 ---
 expression:
 let a.b = 2; in { b = a.c; }

--- a/bin/tests/snapshots/manual_inherit_from__lint_b169f7b47a1e5a5efcfc052399cd20e9c361b5dcdaeca5c91d7719a2b9561712.snap
+++ b/bin/tests/snapshots/manual_inherit_from__lint_b169f7b47a1e5a5efcfc052399cd20e9c361b5dcdaeca5c91d7719a2b9561712.snap
@@ -1,5 +1,7 @@
 ---
 source: bin/tests/manual_inherit_from.rs
-expression: "\"let foo = { }; in { x = foo.x or false; }\""
+expression: snapshot
 ---
-
+expression:
+let foo = { }; in { x = foo.x or false; }
+---

--- a/bin/tests/snapshots/manual_inherit_from__lint_b169f7b47a1e5a5efcfc052399cd20e9c361b5dcdaeca5c91d7719a2b9561712.snap
+++ b/bin/tests/snapshots/manual_inherit_from__lint_b169f7b47a1e5a5efcfc052399cd20e9c361b5dcdaeca5c91d7719a2b9561712.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/manual_inherit_from.rs
 ---
-expression:
 let foo = { }; in { x = foo.x or false; }
 ---

--- a/bin/tests/snapshots/manual_inherit_from__lint_b169f7b47a1e5a5efcfc052399cd20e9c361b5dcdaeca5c91d7719a2b9561712.snap
+++ b/bin/tests/snapshots/manual_inherit_from__lint_b169f7b47a1e5a5efcfc052399cd20e9c361b5dcdaeca5c91d7719a2b9561712.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/manual_inherit_from.rs
-expression: snapshot
 ---
 expression:
 let foo = { }; in { x = foo.x or false; }

--- a/bin/tests/snapshots/manual_inherit_from__lint_d185f6bcc057384cb2f1ae3abb567fd17572eaaa2c3209abd0f527f3fe7e26a1.snap
+++ b/bin/tests/snapshots/manual_inherit_from__lint_d185f6bcc057384cb2f1ae3abb567fd17572eaaa2c3209abd0f527f3fe7e26a1.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/manual_inherit_from.rs
-expression: snapshot
 ---
 expression:
 let a.b = 2; in { b = a.b; }

--- a/bin/tests/snapshots/manual_inherit_from__lint_d185f6bcc057384cb2f1ae3abb567fd17572eaaa2c3209abd0f527f3fe7e26a1.snap
+++ b/bin/tests/snapshots/manual_inherit_from__lint_d185f6bcc057384cb2f1ae3abb567fd17572eaaa2c3209abd0f527f3fe7e26a1.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/manual_inherit_from.rs
 ---
-expression:
 let a.b = 2; in { b = a.b; }
 ---
 [W04] Warning: Assignment instead of inherit from

--- a/bin/tests/snapshots/manual_inherit_from__lint_d185f6bcc057384cb2f1ae3abb567fd17572eaaa2c3209abd0f527f3fe7e26a1.snap
+++ b/bin/tests/snapshots/manual_inherit_from__lint_d185f6bcc057384cb2f1ae3abb567fd17572eaaa2c3209abd0f527f3fe7e26a1.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/manual_inherit_from.rs
-expression: "\"let a.b = 2; in { b = a.b; }\""
+expression: snapshot
+---
+expression:
+let a.b = 2; in { b = a.b; }
 ---
 [W04] Warning: Assignment instead of inherit from
    ╭─[<temp_file_path>:1:19]

--- a/bin/tests/snapshots/manual_inherit_from__lint_fddffc3b779f8727d3ce7613925d3d3df2bc6cc9a30841fe104e26219ed72187.snap
+++ b/bin/tests/snapshots/manual_inherit_from__lint_fddffc3b779f8727d3ce7613925d3d3df2bc6cc9a30841fe104e26219ed72187.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/manual_inherit_from.rs
-expression: "\"let a.b = 2; in { c = a.c; }\""
+expression: snapshot
+---
+expression:
+let a.b = 2; in { c = a.c; }
 ---
 [W04] Warning: Assignment instead of inherit from
    ╭─[<temp_file_path>:1:19]

--- a/bin/tests/snapshots/manual_inherit_from__lint_fddffc3b779f8727d3ce7613925d3d3df2bc6cc9a30841fe104e26219ed72187.snap
+++ b/bin/tests/snapshots/manual_inherit_from__lint_fddffc3b779f8727d3ce7613925d3d3df2bc6cc9a30841fe104e26219ed72187.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/manual_inherit_from.rs
-expression: snapshot
 ---
 expression:
 let a.b = 2; in { c = a.c; }

--- a/bin/tests/snapshots/manual_inherit_from__lint_fddffc3b779f8727d3ce7613925d3d3df2bc6cc9a30841fe104e26219ed72187.snap
+++ b/bin/tests/snapshots/manual_inherit_from__lint_fddffc3b779f8727d3ce7613925d3d3df2bc6cc9a30841fe104e26219ed72187.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/manual_inherit_from.rs
 ---
-expression:
 let a.b = 2; in { c = a.c; }
 ---
 [W04] Warning: Assignment instead of inherit from

--- a/bin/tests/snapshots/redundant_pattern_bind__fix_01ae2aa8e74bbccf70f47469dad2c734944f7d3e39cd86cce214566a1fca2c0f.snap
+++ b/bin/tests/snapshots/redundant_pattern_bind__fix_01ae2aa8e74bbccf70f47469dad2c734944f7d3e39cd86cce214566a1fca2c0f.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/redundant_pattern_bind.rs
-expression: snapshot
 ---
 expression:
 { ... } @ inputs: null

--- a/bin/tests/snapshots/redundant_pattern_bind__fix_01ae2aa8e74bbccf70f47469dad2c734944f7d3e39cd86cce214566a1fca2c0f.snap
+++ b/bin/tests/snapshots/redundant_pattern_bind__fix_01ae2aa8e74bbccf70f47469dad2c734944f7d3e39cd86cce214566a1fca2c0f.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/redundant_pattern_bind.rs
-expression: "\"{ ... } @ inputs: null\""
+expression: snapshot
+---
+expression:
+{ ... } @ inputs: null
 ---
 --- <temp_file_path>
 +++ <temp_file_path> [fixed]

--- a/bin/tests/snapshots/redundant_pattern_bind__fix_01ae2aa8e74bbccf70f47469dad2c734944f7d3e39cd86cce214566a1fca2c0f.snap
+++ b/bin/tests/snapshots/redundant_pattern_bind__fix_01ae2aa8e74bbccf70f47469dad2c734944f7d3e39cd86cce214566a1fca2c0f.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/redundant_pattern_bind.rs
 ---
-expression:
 { ... } @ inputs: null
 ---
 --- <temp_file_path>

--- a/bin/tests/snapshots/redundant_pattern_bind__lint_01ae2aa8e74bbccf70f47469dad2c734944f7d3e39cd86cce214566a1fca2c0f.snap
+++ b/bin/tests/snapshots/redundant_pattern_bind__lint_01ae2aa8e74bbccf70f47469dad2c734944f7d3e39cd86cce214566a1fca2c0f.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/redundant_pattern_bind.rs
-expression: "\"{ ... } @ inputs: null\""
+expression: snapshot
+---
+expression:
+{ ... } @ inputs: null
 ---
 [W11] Warning: Found redundant pattern bind in function argument
    ╭─[<temp_file_path>:1:1]

--- a/bin/tests/snapshots/redundant_pattern_bind__lint_01ae2aa8e74bbccf70f47469dad2c734944f7d3e39cd86cce214566a1fca2c0f.snap
+++ b/bin/tests/snapshots/redundant_pattern_bind__lint_01ae2aa8e74bbccf70f47469dad2c734944f7d3e39cd86cce214566a1fca2c0f.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/redundant_pattern_bind.rs
-expression: snapshot
 ---
 expression:
 { ... } @ inputs: null

--- a/bin/tests/snapshots/redundant_pattern_bind__lint_01ae2aa8e74bbccf70f47469dad2c734944f7d3e39cd86cce214566a1fca2c0f.snap
+++ b/bin/tests/snapshots/redundant_pattern_bind__lint_01ae2aa8e74bbccf70f47469dad2c734944f7d3e39cd86cce214566a1fca2c0f.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/redundant_pattern_bind.rs
 ---
-expression:
 { ... } @ inputs: null
 ---
 [W11] Warning: Found redundant pattern bind in function argument

--- a/bin/tests/snapshots/repeated_keys__fix_107c49dd2c0b84878c81852acfd4aee37038d8367b6bc7f5b43ce051c24908e5.snap
+++ b/bin/tests/snapshots/repeated_keys__fix_107c49dd2c0b84878c81852acfd4aee37038d8367b6bc7f5b43ce051c24908e5.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/repeated_keys.rs
-expression: snapshot
 ---
 expression:
 {

--- a/bin/tests/snapshots/repeated_keys__fix_107c49dd2c0b84878c81852acfd4aee37038d8367b6bc7f5b43ce051c24908e5.snap
+++ b/bin/tests/snapshots/repeated_keys__fix_107c49dd2c0b84878c81852acfd4aee37038d8367b6bc7f5b43ce051c24908e5.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/repeated_keys.rs
 ---
-expression:
 {
   foo.bar = 1;
   foo.bar."hello" = 1;

--- a/bin/tests/snapshots/repeated_keys__fix_107c49dd2c0b84878c81852acfd4aee37038d8367b6bc7f5b43ce051c24908e5.snap
+++ b/bin/tests/snapshots/repeated_keys__fix_107c49dd2c0b84878c81852acfd4aee37038d8367b6bc7f5b43ce051c24908e5.snap
@@ -1,5 +1,12 @@
 ---
 source: bin/tests/repeated_keys.rs
-expression: "\"{\\n  foo.bar = 1;\\n  foo.bar.\\\"hello\\\" = 1;\\n  foo.again = 1;\\n}\\n\""
+expression: snapshot
 ---
+expression:
+{
+  foo.bar = 1;
+  foo.bar."hello" = 1;
+  foo.again = 1;
+}
 
+---

--- a/bin/tests/snapshots/repeated_keys__fix_2987d09ebf239c581be44d6a044ceb0290e769e15f802483ec2f796af57c4e0a.snap
+++ b/bin/tests/snapshots/repeated_keys__fix_2987d09ebf239c581be44d6a044ceb0290e769e15f802483ec2f796af57c4e0a.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/repeated_keys.rs
-expression: snapshot
 ---
 expression:
 { foo.bar = 1; }

--- a/bin/tests/snapshots/repeated_keys__fix_2987d09ebf239c581be44d6a044ceb0290e769e15f802483ec2f796af57c4e0a.snap
+++ b/bin/tests/snapshots/repeated_keys__fix_2987d09ebf239c581be44d6a044ceb0290e769e15f802483ec2f796af57c4e0a.snap
@@ -1,5 +1,7 @@
 ---
 source: bin/tests/repeated_keys.rs
-expression: "\"{ foo.bar = 1; }\""
+expression: snapshot
 ---
-
+expression:
+{ foo.bar = 1; }
+---

--- a/bin/tests/snapshots/repeated_keys__fix_2987d09ebf239c581be44d6a044ceb0290e769e15f802483ec2f796af57c4e0a.snap
+++ b/bin/tests/snapshots/repeated_keys__fix_2987d09ebf239c581be44d6a044ceb0290e769e15f802483ec2f796af57c4e0a.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/repeated_keys.rs
 ---
-expression:
 { foo.bar = 1; }
 ---

--- a/bin/tests/snapshots/repeated_keys__fix_653aae0c9fb8b448e30e62c7daa38519eded4ba2078838f788b3e769db564123.snap
+++ b/bin/tests/snapshots/repeated_keys__fix_653aae0c9fb8b448e30e62c7daa38519eded4ba2078838f788b3e769db564123.snap
@@ -1,5 +1,14 @@
 ---
 source: bin/tests/repeated_keys.rs
-expression: "\"{\\n  foo.baz.bar1 = 1;\\n  foo.baz.bar2 = 2;\\n  foo.baz.bar3 = 3;\\n  foo.baz.bar4 = 4;\\n  foo.baz.bar5 = 5;\\n}\\n\""
+expression: snapshot
 ---
+expression:
+{
+  foo.baz.bar1 = 1;
+  foo.baz.bar2 = 2;
+  foo.baz.bar3 = 3;
+  foo.baz.bar4 = 4;
+  foo.baz.bar5 = 5;
+}
 
+---

--- a/bin/tests/snapshots/repeated_keys__fix_653aae0c9fb8b448e30e62c7daa38519eded4ba2078838f788b3e769db564123.snap
+++ b/bin/tests/snapshots/repeated_keys__fix_653aae0c9fb8b448e30e62c7daa38519eded4ba2078838f788b3e769db564123.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/repeated_keys.rs
-expression: snapshot
 ---
 expression:
 {

--- a/bin/tests/snapshots/repeated_keys__fix_653aae0c9fb8b448e30e62c7daa38519eded4ba2078838f788b3e769db564123.snap
+++ b/bin/tests/snapshots/repeated_keys__fix_653aae0c9fb8b448e30e62c7daa38519eded4ba2078838f788b3e769db564123.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/repeated_keys.rs
 ---
-expression:
 {
   foo.baz.bar1 = 1;
   foo.baz.bar2 = 2;

--- a/bin/tests/snapshots/repeated_keys__fix_7928b443d258628d0f648fe2e30278f84cbe97274683df67fd436584732d7b2c.snap
+++ b/bin/tests/snapshots/repeated_keys__fix_7928b443d258628d0f648fe2e30278f84cbe97274683df67fd436584732d7b2c.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/repeated_keys.rs
 ---
-expression:
 rec {
   foo.x = foo.y;
   foo.y = 2;

--- a/bin/tests/snapshots/repeated_keys__fix_7928b443d258628d0f648fe2e30278f84cbe97274683df67fd436584732d7b2c.snap
+++ b/bin/tests/snapshots/repeated_keys__fix_7928b443d258628d0f648fe2e30278f84cbe97274683df67fd436584732d7b2c.snap
@@ -1,5 +1,12 @@
 ---
 source: bin/tests/repeated_keys.rs
-expression: "\"rec {\\n  foo.x = foo.y;\\n  foo.y = 2;\\n  foo.z = 3;\\n}\\n\""
+expression: snapshot
 ---
+expression:
+rec {
+  foo.x = foo.y;
+  foo.y = 2;
+  foo.z = 3;
+}
 
+---

--- a/bin/tests/snapshots/repeated_keys__fix_7928b443d258628d0f648fe2e30278f84cbe97274683df67fd436584732d7b2c.snap
+++ b/bin/tests/snapshots/repeated_keys__fix_7928b443d258628d0f648fe2e30278f84cbe97274683df67fd436584732d7b2c.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/repeated_keys.rs
-expression: snapshot
 ---
 expression:
 rec {

--- a/bin/tests/snapshots/repeated_keys__lint_107c49dd2c0b84878c81852acfd4aee37038d8367b6bc7f5b43ce051c24908e5.snap
+++ b/bin/tests/snapshots/repeated_keys__lint_107c49dd2c0b84878c81852acfd4aee37038d8367b6bc7f5b43ce051c24908e5.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/repeated_keys.rs
-expression: snapshot
 ---
 expression:
 {

--- a/bin/tests/snapshots/repeated_keys__lint_107c49dd2c0b84878c81852acfd4aee37038d8367b6bc7f5b43ce051c24908e5.snap
+++ b/bin/tests/snapshots/repeated_keys__lint_107c49dd2c0b84878c81852acfd4aee37038d8367b6bc7f5b43ce051c24908e5.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/repeated_keys.rs
 ---
-expression:
 {
   foo.bar = 1;
   foo.bar."hello" = 1;

--- a/bin/tests/snapshots/repeated_keys__lint_107c49dd2c0b84878c81852acfd4aee37038d8367b6bc7f5b43ce051c24908e5.snap
+++ b/bin/tests/snapshots/repeated_keys__lint_107c49dd2c0b84878c81852acfd4aee37038d8367b6bc7f5b43ce051c24908e5.snap
@@ -1,6 +1,14 @@
 ---
 source: bin/tests/repeated_keys.rs
-expression: "\"{\\n  foo.bar = 1;\\n  foo.bar.\\\"hello\\\" = 1;\\n  foo.again = 1;\\n}\\n\""
+expression: snapshot
+---
+expression:
+{
+  foo.bar = 1;
+  foo.bar."hello" = 1;
+  foo.again = 1;
+}
+
 ---
 [W20] Warning: Avoid repeated keys in attribute sets
    ╭─[<temp_file_path>:2:3]

--- a/bin/tests/snapshots/repeated_keys__lint_2987d09ebf239c581be44d6a044ceb0290e769e15f802483ec2f796af57c4e0a.snap
+++ b/bin/tests/snapshots/repeated_keys__lint_2987d09ebf239c581be44d6a044ceb0290e769e15f802483ec2f796af57c4e0a.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/repeated_keys.rs
-expression: snapshot
 ---
 expression:
 { foo.bar = 1; }

--- a/bin/tests/snapshots/repeated_keys__lint_2987d09ebf239c581be44d6a044ceb0290e769e15f802483ec2f796af57c4e0a.snap
+++ b/bin/tests/snapshots/repeated_keys__lint_2987d09ebf239c581be44d6a044ceb0290e769e15f802483ec2f796af57c4e0a.snap
@@ -1,5 +1,7 @@
 ---
 source: bin/tests/repeated_keys.rs
-expression: "\"{ foo.bar = 1; }\""
+expression: snapshot
 ---
-
+expression:
+{ foo.bar = 1; }
+---

--- a/bin/tests/snapshots/repeated_keys__lint_2987d09ebf239c581be44d6a044ceb0290e769e15f802483ec2f796af57c4e0a.snap
+++ b/bin/tests/snapshots/repeated_keys__lint_2987d09ebf239c581be44d6a044ceb0290e769e15f802483ec2f796af57c4e0a.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/repeated_keys.rs
 ---
-expression:
 { foo.bar = 1; }
 ---

--- a/bin/tests/snapshots/repeated_keys__lint_653aae0c9fb8b448e30e62c7daa38519eded4ba2078838f788b3e769db564123.snap
+++ b/bin/tests/snapshots/repeated_keys__lint_653aae0c9fb8b448e30e62c7daa38519eded4ba2078838f788b3e769db564123.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/repeated_keys.rs
-expression: snapshot
 ---
 expression:
 {

--- a/bin/tests/snapshots/repeated_keys__lint_653aae0c9fb8b448e30e62c7daa38519eded4ba2078838f788b3e769db564123.snap
+++ b/bin/tests/snapshots/repeated_keys__lint_653aae0c9fb8b448e30e62c7daa38519eded4ba2078838f788b3e769db564123.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/repeated_keys.rs
 ---
-expression:
 {
   foo.baz.bar1 = 1;
   foo.baz.bar2 = 2;

--- a/bin/tests/snapshots/repeated_keys__lint_653aae0c9fb8b448e30e62c7daa38519eded4ba2078838f788b3e769db564123.snap
+++ b/bin/tests/snapshots/repeated_keys__lint_653aae0c9fb8b448e30e62c7daa38519eded4ba2078838f788b3e769db564123.snap
@@ -1,6 +1,16 @@
 ---
 source: bin/tests/repeated_keys.rs
-expression: "\"{\\n  foo.baz.bar1 = 1;\\n  foo.baz.bar2 = 2;\\n  foo.baz.bar3 = 3;\\n  foo.baz.bar4 = 4;\\n  foo.baz.bar5 = 5;\\n}\\n\""
+expression: snapshot
+---
+expression:
+{
+  foo.baz.bar1 = 1;
+  foo.baz.bar2 = 2;
+  foo.baz.bar3 = 3;
+  foo.baz.bar4 = 4;
+  foo.baz.bar5 = 5;
+}
+
 ---
 [W20] Warning: Avoid repeated keys in attribute sets
    ╭─[<temp_file_path>:2:3]

--- a/bin/tests/snapshots/repeated_keys__lint_7928b443d258628d0f648fe2e30278f84cbe97274683df67fd436584732d7b2c.snap
+++ b/bin/tests/snapshots/repeated_keys__lint_7928b443d258628d0f648fe2e30278f84cbe97274683df67fd436584732d7b2c.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/repeated_keys.rs
 ---
-expression:
 rec {
   foo.x = foo.y;
   foo.y = 2;

--- a/bin/tests/snapshots/repeated_keys__lint_7928b443d258628d0f648fe2e30278f84cbe97274683df67fd436584732d7b2c.snap
+++ b/bin/tests/snapshots/repeated_keys__lint_7928b443d258628d0f648fe2e30278f84cbe97274683df67fd436584732d7b2c.snap
@@ -1,5 +1,12 @@
 ---
 source: bin/tests/repeated_keys.rs
-expression: "\"rec {\\n  foo.x = foo.y;\\n  foo.y = 2;\\n  foo.z = 3;\\n}\\n\""
+expression: snapshot
 ---
+expression:
+rec {
+  foo.x = foo.y;
+  foo.y = 2;
+  foo.z = 3;
+}
 
+---

--- a/bin/tests/snapshots/repeated_keys__lint_7928b443d258628d0f648fe2e30278f84cbe97274683df67fd436584732d7b2c.snap
+++ b/bin/tests/snapshots/repeated_keys__lint_7928b443d258628d0f648fe2e30278f84cbe97274683df67fd436584732d7b2c.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/repeated_keys.rs
-expression: snapshot
 ---
 expression:
 rec {

--- a/bin/tests/snapshots/unquoted_uri__fix_33baa84c37bca40983a14f7acf371ef056c6037384f9ceb0389472c2c4ce4327.snap
+++ b/bin/tests/snapshots/unquoted_uri__fix_33baa84c37bca40983a14f7acf371ef056c6037384f9ceb0389472c2c4ce4327.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/unquoted_uri.rs
-expression: "\"github:nerdypepper/statix\""
+expression: snapshot
+---
+expression:
+github:nerdypepper/statix
 ---
 --- <temp_file_path>
 +++ <temp_file_path> [fixed]

--- a/bin/tests/snapshots/unquoted_uri__fix_33baa84c37bca40983a14f7acf371ef056c6037384f9ceb0389472c2c4ce4327.snap
+++ b/bin/tests/snapshots/unquoted_uri__fix_33baa84c37bca40983a14f7acf371ef056c6037384f9ceb0389472c2c4ce4327.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/unquoted_uri.rs
-expression: snapshot
 ---
 expression:
 github:nerdypepper/statix

--- a/bin/tests/snapshots/unquoted_uri__fix_33baa84c37bca40983a14f7acf371ef056c6037384f9ceb0389472c2c4ce4327.snap
+++ b/bin/tests/snapshots/unquoted_uri__fix_33baa84c37bca40983a14f7acf371ef056c6037384f9ceb0389472c2c4ce4327.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/unquoted_uri.rs
 ---
-expression:
 github:nerdypepper/statix
 ---
 --- <temp_file_path>

--- a/bin/tests/snapshots/unquoted_uri__lint_33baa84c37bca40983a14f7acf371ef056c6037384f9ceb0389472c2c4ce4327.snap
+++ b/bin/tests/snapshots/unquoted_uri__lint_33baa84c37bca40983a14f7acf371ef056c6037384f9ceb0389472c2c4ce4327.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/unquoted_uri.rs
 ---
-expression:
 github:nerdypepper/statix
 ---
 [W12] Warning: Found unquoted URI expression

--- a/bin/tests/snapshots/unquoted_uri__lint_33baa84c37bca40983a14f7acf371ef056c6037384f9ceb0389472c2c4ce4327.snap
+++ b/bin/tests/snapshots/unquoted_uri__lint_33baa84c37bca40983a14f7acf371ef056c6037384f9ceb0389472c2c4ce4327.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/unquoted_uri.rs
-expression: "\"github:nerdypepper/statix\""
+expression: snapshot
+---
+expression:
+github:nerdypepper/statix
 ---
 [W12] Warning: Found unquoted URI expression
    ╭─[<temp_file_path>:1:1]

--- a/bin/tests/snapshots/unquoted_uri__lint_33baa84c37bca40983a14f7acf371ef056c6037384f9ceb0389472c2c4ce4327.snap
+++ b/bin/tests/snapshots/unquoted_uri__lint_33baa84c37bca40983a14f7acf371ef056c6037384f9ceb0389472c2c4ce4327.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/unquoted_uri.rs
-expression: snapshot
 ---
 expression:
 github:nerdypepper/statix

--- a/bin/tests/snapshots/useless_has_attr__fix_3c62cf80cceead28f219a180d924a9293dbb692ce56d6c91e10e49790390913a.snap
+++ b/bin/tests/snapshots/useless_has_attr__fix_3c62cf80cceead28f219a180d924a9293dbb692ce56d6c91e10e49790390913a.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/useless_has_attr.rs
-expression: "\"if x ? a.b then x.a.b else default\""
+expression: snapshot
+---
+expression:
+if x ? a.b then x.a.b else default
 ---
 --- <temp_file_path>
 +++ <temp_file_path> [fixed]

--- a/bin/tests/snapshots/useless_has_attr__fix_3c62cf80cceead28f219a180d924a9293dbb692ce56d6c91e10e49790390913a.snap
+++ b/bin/tests/snapshots/useless_has_attr__fix_3c62cf80cceead28f219a180d924a9293dbb692ce56d6c91e10e49790390913a.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/useless_has_attr.rs
-expression: snapshot
 ---
 expression:
 if x ? a.b then x.a.b else default

--- a/bin/tests/snapshots/useless_has_attr__fix_3c62cf80cceead28f219a180d924a9293dbb692ce56d6c91e10e49790390913a.snap
+++ b/bin/tests/snapshots/useless_has_attr__fix_3c62cf80cceead28f219a180d924a9293dbb692ce56d6c91e10e49790390913a.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/useless_has_attr.rs
 ---
-expression:
 if x ? a.b then x.a.b else default
 ---
 --- <temp_file_path>

--- a/bin/tests/snapshots/useless_has_attr__fix_514032635e11fe0f21c05881885de04587ba8db14854db99efccb6bb57f7bf8c.snap
+++ b/bin/tests/snapshots/useless_has_attr__fix_514032635e11fe0f21c05881885de04587ba8db14854db99efccb6bb57f7bf8c.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/useless_has_attr.rs
-expression: "\"if x ? a then x.a else default\""
+expression: snapshot
+---
+expression:
+if x ? a then x.a else default
 ---
 --- <temp_file_path>
 +++ <temp_file_path> [fixed]

--- a/bin/tests/snapshots/useless_has_attr__fix_514032635e11fe0f21c05881885de04587ba8db14854db99efccb6bb57f7bf8c.snap
+++ b/bin/tests/snapshots/useless_has_attr__fix_514032635e11fe0f21c05881885de04587ba8db14854db99efccb6bb57f7bf8c.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/useless_has_attr.rs
-expression: snapshot
 ---
 expression:
 if x ? a then x.a else default

--- a/bin/tests/snapshots/useless_has_attr__fix_514032635e11fe0f21c05881885de04587ba8db14854db99efccb6bb57f7bf8c.snap
+++ b/bin/tests/snapshots/useless_has_attr__fix_514032635e11fe0f21c05881885de04587ba8db14854db99efccb6bb57f7bf8c.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/useless_has_attr.rs
 ---
-expression:
 if x ? a then x.a else default
 ---
 --- <temp_file_path>

--- a/bin/tests/snapshots/useless_has_attr__fix_9361572e1b83dd76c88aa8af9b983c7f255936c0326d983f21be6622852e970d.snap
+++ b/bin/tests/snapshots/useless_has_attr__fix_9361572e1b83dd76c88aa8af9b983c7f255936c0326d983f21be6622852e970d.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/useless_has_attr.rs
 ---
-expression:
 if x ? a then x.a else if b then c else d
 ---
 --- <temp_file_path>

--- a/bin/tests/snapshots/useless_has_attr__fix_9361572e1b83dd76c88aa8af9b983c7f255936c0326d983f21be6622852e970d.snap
+++ b/bin/tests/snapshots/useless_has_attr__fix_9361572e1b83dd76c88aa8af9b983c7f255936c0326d983f21be6622852e970d.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/useless_has_attr.rs
-expression: "\"if x ? a then x.a else if b then c else d\""
+expression: snapshot
+---
+expression:
+if x ? a then x.a else if b then c else d
 ---
 --- <temp_file_path>
 +++ <temp_file_path> [fixed]

--- a/bin/tests/snapshots/useless_has_attr__fix_9361572e1b83dd76c88aa8af9b983c7f255936c0326d983f21be6622852e970d.snap
+++ b/bin/tests/snapshots/useless_has_attr__fix_9361572e1b83dd76c88aa8af9b983c7f255936c0326d983f21be6622852e970d.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/useless_has_attr.rs
-expression: snapshot
 ---
 expression:
 if x ? a then x.a else if b then c else d

--- a/bin/tests/snapshots/useless_has_attr__fix_dcdeee74e5d10b5199175881fce69d02c82ff9084bcc346492482aa279e29160.snap
+++ b/bin/tests/snapshots/useless_has_attr__fix_dcdeee74e5d10b5199175881fce69d02c82ff9084bcc346492482aa279e29160.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/useless_has_attr.rs
 ---
-expression:
 if x.a ? b then x.a.b else default
 ---
 --- <temp_file_path>

--- a/bin/tests/snapshots/useless_has_attr__fix_dcdeee74e5d10b5199175881fce69d02c82ff9084bcc346492482aa279e29160.snap
+++ b/bin/tests/snapshots/useless_has_attr__fix_dcdeee74e5d10b5199175881fce69d02c82ff9084bcc346492482aa279e29160.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/useless_has_attr.rs
-expression: snapshot
 ---
 expression:
 if x.a ? b then x.a.b else default

--- a/bin/tests/snapshots/useless_has_attr__fix_dcdeee74e5d10b5199175881fce69d02c82ff9084bcc346492482aa279e29160.snap
+++ b/bin/tests/snapshots/useless_has_attr__fix_dcdeee74e5d10b5199175881fce69d02c82ff9084bcc346492482aa279e29160.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/useless_has_attr.rs
-expression: "\"if x.a ? b then x.a.b else default\""
+expression: snapshot
+---
+expression:
+if x.a ? b then x.a.b else default
 ---
 --- <temp_file_path>
 +++ <temp_file_path> [fixed]

--- a/bin/tests/snapshots/useless_has_attr__fix_f5edc729a910faa40ea89cb086561a4390af9bdbc4fa3ffdee8e1ce406fba484.snap
+++ b/bin/tests/snapshots/useless_has_attr__fix_f5edc729a910faa40ea89cb086561a4390af9bdbc4fa3ffdee8e1ce406fba484.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/useless_has_attr.rs
 ---
-expression:
 if x ? a then x.a else b.c
 ---
 --- <temp_file_path>

--- a/bin/tests/snapshots/useless_has_attr__fix_f5edc729a910faa40ea89cb086561a4390af9bdbc4fa3ffdee8e1ce406fba484.snap
+++ b/bin/tests/snapshots/useless_has_attr__fix_f5edc729a910faa40ea89cb086561a4390af9bdbc4fa3ffdee8e1ce406fba484.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/useless_has_attr.rs
-expression: "\"if x ? a then x.a else b.c\""
+expression: snapshot
+---
+expression:
+if x ? a then x.a else b.c
 ---
 --- <temp_file_path>
 +++ <temp_file_path> [fixed]

--- a/bin/tests/snapshots/useless_has_attr__fix_f5edc729a910faa40ea89cb086561a4390af9bdbc4fa3ffdee8e1ce406fba484.snap
+++ b/bin/tests/snapshots/useless_has_attr__fix_f5edc729a910faa40ea89cb086561a4390af9bdbc4fa3ffdee8e1ce406fba484.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/useless_has_attr.rs
-expression: snapshot
 ---
 expression:
 if x ? a then x.a else b.c

--- a/bin/tests/snapshots/useless_has_attr__lint_3c62cf80cceead28f219a180d924a9293dbb692ce56d6c91e10e49790390913a.snap
+++ b/bin/tests/snapshots/useless_has_attr__lint_3c62cf80cceead28f219a180d924a9293dbb692ce56d6c91e10e49790390913a.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/useless_has_attr.rs
 ---
-expression:
 if x ? a.b then x.a.b else default
 ---
 [W19] Warning: This `if` expression can be simplified with `or`

--- a/bin/tests/snapshots/useless_has_attr__lint_3c62cf80cceead28f219a180d924a9293dbb692ce56d6c91e10e49790390913a.snap
+++ b/bin/tests/snapshots/useless_has_attr__lint_3c62cf80cceead28f219a180d924a9293dbb692ce56d6c91e10e49790390913a.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/useless_has_attr.rs
-expression: "\"if x ? a.b then x.a.b else default\""
+expression: snapshot
+---
+expression:
+if x ? a.b then x.a.b else default
 ---
 [W19] Warning: This `if` expression can be simplified with `or`
    ╭─[<temp_file_path>:1:1]

--- a/bin/tests/snapshots/useless_has_attr__lint_3c62cf80cceead28f219a180d924a9293dbb692ce56d6c91e10e49790390913a.snap
+++ b/bin/tests/snapshots/useless_has_attr__lint_3c62cf80cceead28f219a180d924a9293dbb692ce56d6c91e10e49790390913a.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/useless_has_attr.rs
-expression: snapshot
 ---
 expression:
 if x ? a.b then x.a.b else default

--- a/bin/tests/snapshots/useless_has_attr__lint_514032635e11fe0f21c05881885de04587ba8db14854db99efccb6bb57f7bf8c.snap
+++ b/bin/tests/snapshots/useless_has_attr__lint_514032635e11fe0f21c05881885de04587ba8db14854db99efccb6bb57f7bf8c.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/useless_has_attr.rs
 ---
-expression:
 if x ? a then x.a else default
 ---
 [W19] Warning: This `if` expression can be simplified with `or`

--- a/bin/tests/snapshots/useless_has_attr__lint_514032635e11fe0f21c05881885de04587ba8db14854db99efccb6bb57f7bf8c.snap
+++ b/bin/tests/snapshots/useless_has_attr__lint_514032635e11fe0f21c05881885de04587ba8db14854db99efccb6bb57f7bf8c.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/useless_has_attr.rs
-expression: snapshot
 ---
 expression:
 if x ? a then x.a else default

--- a/bin/tests/snapshots/useless_has_attr__lint_514032635e11fe0f21c05881885de04587ba8db14854db99efccb6bb57f7bf8c.snap
+++ b/bin/tests/snapshots/useless_has_attr__lint_514032635e11fe0f21c05881885de04587ba8db14854db99efccb6bb57f7bf8c.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/useless_has_attr.rs
-expression: "\"if x ? a then x.a else default\""
+expression: snapshot
+---
+expression:
+if x ? a then x.a else default
 ---
 [W19] Warning: This `if` expression can be simplified with `or`
    ╭─[<temp_file_path>:1:1]

--- a/bin/tests/snapshots/useless_has_attr__lint_9361572e1b83dd76c88aa8af9b983c7f255936c0326d983f21be6622852e970d.snap
+++ b/bin/tests/snapshots/useless_has_attr__lint_9361572e1b83dd76c88aa8af9b983c7f255936c0326d983f21be6622852e970d.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/useless_has_attr.rs
 ---
-expression:
 if x ? a then x.a else if b then c else d
 ---
 [W19] Warning: This `if` expression can be simplified with `or`

--- a/bin/tests/snapshots/useless_has_attr__lint_9361572e1b83dd76c88aa8af9b983c7f255936c0326d983f21be6622852e970d.snap
+++ b/bin/tests/snapshots/useless_has_attr__lint_9361572e1b83dd76c88aa8af9b983c7f255936c0326d983f21be6622852e970d.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/useless_has_attr.rs
-expression: "\"if x ? a then x.a else if b then c else d\""
+expression: snapshot
+---
+expression:
+if x ? a then x.a else if b then c else d
 ---
 [W19] Warning: This `if` expression can be simplified with `or`
    ╭─[<temp_file_path>:1:1]

--- a/bin/tests/snapshots/useless_has_attr__lint_9361572e1b83dd76c88aa8af9b983c7f255936c0326d983f21be6622852e970d.snap
+++ b/bin/tests/snapshots/useless_has_attr__lint_9361572e1b83dd76c88aa8af9b983c7f255936c0326d983f21be6622852e970d.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/useless_has_attr.rs
-expression: snapshot
 ---
 expression:
 if x ? a then x.a else if b then c else d

--- a/bin/tests/snapshots/useless_has_attr__lint_dcdeee74e5d10b5199175881fce69d02c82ff9084bcc346492482aa279e29160.snap
+++ b/bin/tests/snapshots/useless_has_attr__lint_dcdeee74e5d10b5199175881fce69d02c82ff9084bcc346492482aa279e29160.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/useless_has_attr.rs
-expression: "\"if x.a ? b then x.a.b else default\""
+expression: snapshot
+---
+expression:
+if x.a ? b then x.a.b else default
 ---
 [W19] Warning: This `if` expression can be simplified with `or`
    ╭─[<temp_file_path>:1:1]

--- a/bin/tests/snapshots/useless_has_attr__lint_dcdeee74e5d10b5199175881fce69d02c82ff9084bcc346492482aa279e29160.snap
+++ b/bin/tests/snapshots/useless_has_attr__lint_dcdeee74e5d10b5199175881fce69d02c82ff9084bcc346492482aa279e29160.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/useless_has_attr.rs
 ---
-expression:
 if x.a ? b then x.a.b else default
 ---
 [W19] Warning: This `if` expression can be simplified with `or`

--- a/bin/tests/snapshots/useless_has_attr__lint_dcdeee74e5d10b5199175881fce69d02c82ff9084bcc346492482aa279e29160.snap
+++ b/bin/tests/snapshots/useless_has_attr__lint_dcdeee74e5d10b5199175881fce69d02c82ff9084bcc346492482aa279e29160.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/useless_has_attr.rs
-expression: snapshot
 ---
 expression:
 if x.a ? b then x.a.b else default

--- a/bin/tests/snapshots/useless_has_attr__lint_f5edc729a910faa40ea89cb086561a4390af9bdbc4fa3ffdee8e1ce406fba484.snap
+++ b/bin/tests/snapshots/useless_has_attr__lint_f5edc729a910faa40ea89cb086561a4390af9bdbc4fa3ffdee8e1ce406fba484.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/useless_has_attr.rs
 ---
-expression:
 if x ? a then x.a else b.c
 ---
 [W19] Warning: This `if` expression can be simplified with `or`

--- a/bin/tests/snapshots/useless_has_attr__lint_f5edc729a910faa40ea89cb086561a4390af9bdbc4fa3ffdee8e1ce406fba484.snap
+++ b/bin/tests/snapshots/useless_has_attr__lint_f5edc729a910faa40ea89cb086561a4390af9bdbc4fa3ffdee8e1ce406fba484.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/useless_has_attr.rs
-expression: snapshot
 ---
 expression:
 if x ? a then x.a else b.c

--- a/bin/tests/snapshots/useless_has_attr__lint_f5edc729a910faa40ea89cb086561a4390af9bdbc4fa3ffdee8e1ce406fba484.snap
+++ b/bin/tests/snapshots/useless_has_attr__lint_f5edc729a910faa40ea89cb086561a4390af9bdbc4fa3ffdee8e1ce406fba484.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/useless_has_attr.rs
-expression: "\"if x ? a then x.a else b.c\""
+expression: snapshot
+---
+expression:
+if x ? a then x.a else b.c
 ---
 [W19] Warning: This `if` expression can be simplified with `or`
    ╭─[<temp_file_path>:1:1]

--- a/bin/tests/snapshots/useless_parens__fix_31ac41c8c6e98946b178fde2f6c5a168103df16fc12290ac3f38e5f12d9c67aa.snap
+++ b/bin/tests/snapshots/useless_parens__fix_31ac41c8c6e98946b178fde2f6c5a168103df16fc12290ac3f38e5f12d9c67aa.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/useless_parens.rs
 ---
-expression:
 ("hello")
 ---
 --- <temp_file_path>

--- a/bin/tests/snapshots/useless_parens__fix_31ac41c8c6e98946b178fde2f6c5a168103df16fc12290ac3f38e5f12d9c67aa.snap
+++ b/bin/tests/snapshots/useless_parens__fix_31ac41c8c6e98946b178fde2f6c5a168103df16fc12290ac3f38e5f12d9c67aa.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/useless_parens.rs
-expression: "\"(\\\"hello\\\")\""
+expression: snapshot
+---
+expression:
+("hello")
 ---
 --- <temp_file_path>
 +++ <temp_file_path> [fixed]

--- a/bin/tests/snapshots/useless_parens__fix_31ac41c8c6e98946b178fde2f6c5a168103df16fc12290ac3f38e5f12d9c67aa.snap
+++ b/bin/tests/snapshots/useless_parens__fix_31ac41c8c6e98946b178fde2f6c5a168103df16fc12290ac3f38e5f12d9c67aa.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/useless_parens.rs
-expression: snapshot
 ---
 expression:
 ("hello")

--- a/bin/tests/snapshots/useless_parens__fix_4d37aa86b470346c97523d0152f7860b8d3a5c945516ceb711376e968446e310.snap
+++ b/bin/tests/snapshots/useless_parens__fix_4d37aa86b470346c97523d0152f7860b8d3a5c945516ceb711376e968446e310.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/useless_parens.rs
 ---
-expression:
 let a = (1 + 2); in null
 ---
 --- <temp_file_path>

--- a/bin/tests/snapshots/useless_parens__fix_4d37aa86b470346c97523d0152f7860b8d3a5c945516ceb711376e968446e310.snap
+++ b/bin/tests/snapshots/useless_parens__fix_4d37aa86b470346c97523d0152f7860b8d3a5c945516ceb711376e968446e310.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/useless_parens.rs
-expression: snapshot
 ---
 expression:
 let a = (1 + 2); in null

--- a/bin/tests/snapshots/useless_parens__fix_4d37aa86b470346c97523d0152f7860b8d3a5c945516ceb711376e968446e310.snap
+++ b/bin/tests/snapshots/useless_parens__fix_4d37aa86b470346c97523d0152f7860b8d3a5c945516ceb711376e968446e310.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/useless_parens.rs
-expression: "\"let a = (1 + 2); in null\""
+expression: snapshot
+---
+expression:
+let a = (1 + 2); in null
 ---
 --- <temp_file_path>
 +++ <temp_file_path> [fixed]

--- a/bin/tests/snapshots/useless_parens__fix_518aa31f8b9a466e2e92490ffd87be423d3e42cf20c228150cef6c88bbd4fb11.snap
+++ b/bin/tests/snapshots/useless_parens__fix_518aa31f8b9a466e2e92490ffd87be423d3e42cf20c228150cef6c88bbd4fb11.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/useless_parens.rs
-expression: snapshot
 ---
 expression:
 let h = ({ inherit (builtins) map; }); in null

--- a/bin/tests/snapshots/useless_parens__fix_518aa31f8b9a466e2e92490ffd87be423d3e42cf20c228150cef6c88bbd4fb11.snap
+++ b/bin/tests/snapshots/useless_parens__fix_518aa31f8b9a466e2e92490ffd87be423d3e42cf20c228150cef6c88bbd4fb11.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/useless_parens.rs
-expression: "\"let h = ({ inherit (builtins) map; }); in null\""
+expression: snapshot
+---
+expression:
+let h = ({ inherit (builtins) map; }); in null
 ---
 --- <temp_file_path>
 +++ <temp_file_path> [fixed]

--- a/bin/tests/snapshots/useless_parens__fix_518aa31f8b9a466e2e92490ffd87be423d3e42cf20c228150cef6c88bbd4fb11.snap
+++ b/bin/tests/snapshots/useless_parens__fix_518aa31f8b9a466e2e92490ffd87be423d3e42cf20c228150cef6c88bbd4fb11.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/useless_parens.rs
 ---
-expression:
 let h = ({ inherit (builtins) map; }); in null
 ---
 --- <temp_file_path>

--- a/bin/tests/snapshots/useless_parens__fix_67ffd912c9610f8ceb69fbfed2ee46908a1d4bcba43542f10eac24a50b0d8d11.snap
+++ b/bin/tests/snapshots/useless_parens__fix_67ffd912c9610f8ceb69fbfed2ee46908a1d4bcba43542f10eac24a50b0d8d11.snap
@@ -1,5 +1,7 @@
 ---
 source: bin/tests/useless_parens.rs
-expression: "\"[(builtins.pam or map)]\""
+expression: snapshot
 ---
-
+expression:
+[(builtins.pam or map)]
+---

--- a/bin/tests/snapshots/useless_parens__fix_67ffd912c9610f8ceb69fbfed2ee46908a1d4bcba43542f10eac24a50b0d8d11.snap
+++ b/bin/tests/snapshots/useless_parens__fix_67ffd912c9610f8ceb69fbfed2ee46908a1d4bcba43542f10eac24a50b0d8d11.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/useless_parens.rs
 ---
-expression:
 [(builtins.pam or map)]
 ---

--- a/bin/tests/snapshots/useless_parens__fix_67ffd912c9610f8ceb69fbfed2ee46908a1d4bcba43542f10eac24a50b0d8d11.snap
+++ b/bin/tests/snapshots/useless_parens__fix_67ffd912c9610f8ceb69fbfed2ee46908a1d4bcba43542f10eac24a50b0d8d11.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/useless_parens.rs
-expression: snapshot
 ---
 expression:
 [(builtins.pam or map)]

--- a/bin/tests/snapshots/useless_parens__fix_dbf237a5ac629f60efb6cc28b28986f3e8f38ab97c28857a2b369399afce1c36.snap
+++ b/bin/tests/snapshots/useless_parens__fix_dbf237a5ac629f60efb6cc28b28986f3e8f38ab97c28857a2b369399afce1c36.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/useless_parens.rs
-expression: snapshot
 ---
 expression:
 [(builtins.map)]

--- a/bin/tests/snapshots/useless_parens__fix_dbf237a5ac629f60efb6cc28b28986f3e8f38ab97c28857a2b369399afce1c36.snap
+++ b/bin/tests/snapshots/useless_parens__fix_dbf237a5ac629f60efb6cc28b28986f3e8f38ab97c28857a2b369399afce1c36.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/useless_parens.rs
 ---
-expression:
 [(builtins.map)]
 ---
 --- <temp_file_path>

--- a/bin/tests/snapshots/useless_parens__fix_dbf237a5ac629f60efb6cc28b28986f3e8f38ab97c28857a2b369399afce1c36.snap
+++ b/bin/tests/snapshots/useless_parens__fix_dbf237a5ac629f60efb6cc28b28986f3e8f38ab97c28857a2b369399afce1c36.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/useless_parens.rs
-expression: "\"[(builtins.map)]\""
+expression: snapshot
+---
+expression:
+[(builtins.map)]
 ---
 --- <temp_file_path>
 +++ <temp_file_path> [fixed]

--- a/bin/tests/snapshots/useless_parens__fix_e77035eacc5250b3a65353c52612eb4a05666249943f2d5c27329a9915a340a9.snap
+++ b/bin/tests/snapshots/useless_parens__fix_e77035eacc5250b3a65353c52612eb4a05666249943f2d5c27329a9915a340a9.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/useless_parens.rs
 ---
-expression:
 ({ f = 2; })
 ---
 --- <temp_file_path>

--- a/bin/tests/snapshots/useless_parens__fix_e77035eacc5250b3a65353c52612eb4a05666249943f2d5c27329a9915a340a9.snap
+++ b/bin/tests/snapshots/useless_parens__fix_e77035eacc5250b3a65353c52612eb4a05666249943f2d5c27329a9915a340a9.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/useless_parens.rs
-expression: "\"({ f = 2; })\""
+expression: snapshot
+---
+expression:
+({ f = 2; })
 ---
 --- <temp_file_path>
 +++ <temp_file_path> [fixed]

--- a/bin/tests/snapshots/useless_parens__fix_e77035eacc5250b3a65353c52612eb4a05666249943f2d5c27329a9915a340a9.snap
+++ b/bin/tests/snapshots/useless_parens__fix_e77035eacc5250b3a65353c52612eb4a05666249943f2d5c27329a9915a340a9.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/useless_parens.rs
-expression: snapshot
 ---
 expression:
 ({ f = 2; })

--- a/bin/tests/snapshots/useless_parens__fix_ed0b445d7f4db791ac8dcf41de7d3bc416d22cc4154b5a58ff82ce1fed6fd3c0.snap
+++ b/bin/tests/snapshots/useless_parens__fix_ed0b445d7f4db791ac8dcf41de7d3bc416d22cc4154b5a58ff82ce1fed6fd3c0.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/useless_parens.rs
-expression: "\"let a = 0; in (null)\""
+expression: snapshot
+---
+expression:
+let a = 0; in (null)
 ---
 --- <temp_file_path>
 +++ <temp_file_path> [fixed]

--- a/bin/tests/snapshots/useless_parens__fix_ed0b445d7f4db791ac8dcf41de7d3bc416d22cc4154b5a58ff82ce1fed6fd3c0.snap
+++ b/bin/tests/snapshots/useless_parens__fix_ed0b445d7f4db791ac8dcf41de7d3bc416d22cc4154b5a58ff82ce1fed6fd3c0.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/useless_parens.rs
 ---
-expression:
 let a = 0; in (null)
 ---
 --- <temp_file_path>

--- a/bin/tests/snapshots/useless_parens__fix_ed0b445d7f4db791ac8dcf41de7d3bc416d22cc4154b5a58ff82ce1fed6fd3c0.snap
+++ b/bin/tests/snapshots/useless_parens__fix_ed0b445d7f4db791ac8dcf41de7d3bc416d22cc4154b5a58ff82ce1fed6fd3c0.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/useless_parens.rs
-expression: snapshot
 ---
 expression:
 let a = 0; in (null)

--- a/bin/tests/snapshots/useless_parens__fix_f04dfa0b3c36c6f2489cba3b913db246cbacd0f646193435d7def64d8bbd9b10.snap
+++ b/bin/tests/snapshots/useless_parens__fix_f04dfa0b3c36c6f2489cba3b913db246cbacd0f646193435d7def64d8bbd9b10.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/useless_parens.rs
 ---
-expression:
 let b = 0; in (b)
 ---
 --- <temp_file_path>

--- a/bin/tests/snapshots/useless_parens__fix_f04dfa0b3c36c6f2489cba3b913db246cbacd0f646193435d7def64d8bbd9b10.snap
+++ b/bin/tests/snapshots/useless_parens__fix_f04dfa0b3c36c6f2489cba3b913db246cbacd0f646193435d7def64d8bbd9b10.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/useless_parens.rs
-expression: snapshot
 ---
 expression:
 let b = 0; in (b)

--- a/bin/tests/snapshots/useless_parens__fix_f04dfa0b3c36c6f2489cba3b913db246cbacd0f646193435d7def64d8bbd9b10.snap
+++ b/bin/tests/snapshots/useless_parens__fix_f04dfa0b3c36c6f2489cba3b913db246cbacd0f646193435d7def64d8bbd9b10.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/useless_parens.rs
-expression: "\"let b = 0; in (b)\""
+expression: snapshot
+---
+expression:
+let b = 0; in (b)
 ---
 --- <temp_file_path>
 +++ <temp_file_path> [fixed]

--- a/bin/tests/snapshots/useless_parens__lint_31ac41c8c6e98946b178fde2f6c5a168103df16fc12290ac3f38e5f12d9c67aa.snap
+++ b/bin/tests/snapshots/useless_parens__lint_31ac41c8c6e98946b178fde2f6c5a168103df16fc12290ac3f38e5f12d9c67aa.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/useless_parens.rs
-expression: snapshot
 ---
 expression:
 ("hello")

--- a/bin/tests/snapshots/useless_parens__lint_31ac41c8c6e98946b178fde2f6c5a168103df16fc12290ac3f38e5f12d9c67aa.snap
+++ b/bin/tests/snapshots/useless_parens__lint_31ac41c8c6e98946b178fde2f6c5a168103df16fc12290ac3f38e5f12d9c67aa.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/useless_parens.rs
-expression: "\"(\\\"hello\\\")\""
+expression: snapshot
+---
+expression:
+("hello")
 ---
 [W08] Warning: These parentheses can be omitted
    ╭─[<temp_file_path>:1:1]

--- a/bin/tests/snapshots/useless_parens__lint_31ac41c8c6e98946b178fde2f6c5a168103df16fc12290ac3f38e5f12d9c67aa.snap
+++ b/bin/tests/snapshots/useless_parens__lint_31ac41c8c6e98946b178fde2f6c5a168103df16fc12290ac3f38e5f12d9c67aa.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/useless_parens.rs
 ---
-expression:
 ("hello")
 ---
 [W08] Warning: These parentheses can be omitted

--- a/bin/tests/snapshots/useless_parens__lint_4d37aa86b470346c97523d0152f7860b8d3a5c945516ceb711376e968446e310.snap
+++ b/bin/tests/snapshots/useless_parens__lint_4d37aa86b470346c97523d0152f7860b8d3a5c945516ceb711376e968446e310.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/useless_parens.rs
-expression: "\"let a = (1 + 2); in null\""
+expression: snapshot
+---
+expression:
+let a = (1 + 2); in null
 ---
 [W08] Warning: These parentheses can be omitted
    ╭─[<temp_file_path>:1:9]

--- a/bin/tests/snapshots/useless_parens__lint_4d37aa86b470346c97523d0152f7860b8d3a5c945516ceb711376e968446e310.snap
+++ b/bin/tests/snapshots/useless_parens__lint_4d37aa86b470346c97523d0152f7860b8d3a5c945516ceb711376e968446e310.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/useless_parens.rs
 ---
-expression:
 let a = (1 + 2); in null
 ---
 [W08] Warning: These parentheses can be omitted

--- a/bin/tests/snapshots/useless_parens__lint_4d37aa86b470346c97523d0152f7860b8d3a5c945516ceb711376e968446e310.snap
+++ b/bin/tests/snapshots/useless_parens__lint_4d37aa86b470346c97523d0152f7860b8d3a5c945516ceb711376e968446e310.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/useless_parens.rs
-expression: snapshot
 ---
 expression:
 let a = (1 + 2); in null

--- a/bin/tests/snapshots/useless_parens__lint_518aa31f8b9a466e2e92490ffd87be423d3e42cf20c228150cef6c88bbd4fb11.snap
+++ b/bin/tests/snapshots/useless_parens__lint_518aa31f8b9a466e2e92490ffd87be423d3e42cf20c228150cef6c88bbd4fb11.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/useless_parens.rs
-expression: snapshot
 ---
 expression:
 let h = ({ inherit (builtins) map; }); in null

--- a/bin/tests/snapshots/useless_parens__lint_518aa31f8b9a466e2e92490ffd87be423d3e42cf20c228150cef6c88bbd4fb11.snap
+++ b/bin/tests/snapshots/useless_parens__lint_518aa31f8b9a466e2e92490ffd87be423d3e42cf20c228150cef6c88bbd4fb11.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/useless_parens.rs
-expression: "\"let h = ({ inherit (builtins) map; }); in null\""
+expression: snapshot
+---
+expression:
+let h = ({ inherit (builtins) map; }); in null
 ---
 [W08] Warning: These parentheses can be omitted
    ╭─[<temp_file_path>:1:9]

--- a/bin/tests/snapshots/useless_parens__lint_518aa31f8b9a466e2e92490ffd87be423d3e42cf20c228150cef6c88bbd4fb11.snap
+++ b/bin/tests/snapshots/useless_parens__lint_518aa31f8b9a466e2e92490ffd87be423d3e42cf20c228150cef6c88bbd4fb11.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/useless_parens.rs
 ---
-expression:
 let h = ({ inherit (builtins) map; }); in null
 ---
 [W08] Warning: These parentheses can be omitted

--- a/bin/tests/snapshots/useless_parens__lint_67ffd912c9610f8ceb69fbfed2ee46908a1d4bcba43542f10eac24a50b0d8d11.snap
+++ b/bin/tests/snapshots/useless_parens__lint_67ffd912c9610f8ceb69fbfed2ee46908a1d4bcba43542f10eac24a50b0d8d11.snap
@@ -1,5 +1,7 @@
 ---
 source: bin/tests/useless_parens.rs
-expression: "\"[(builtins.pam or map)]\""
+expression: snapshot
 ---
-
+expression:
+[(builtins.pam or map)]
+---

--- a/bin/tests/snapshots/useless_parens__lint_67ffd912c9610f8ceb69fbfed2ee46908a1d4bcba43542f10eac24a50b0d8d11.snap
+++ b/bin/tests/snapshots/useless_parens__lint_67ffd912c9610f8ceb69fbfed2ee46908a1d4bcba43542f10eac24a50b0d8d11.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/useless_parens.rs
 ---
-expression:
 [(builtins.pam or map)]
 ---

--- a/bin/tests/snapshots/useless_parens__lint_67ffd912c9610f8ceb69fbfed2ee46908a1d4bcba43542f10eac24a50b0d8d11.snap
+++ b/bin/tests/snapshots/useless_parens__lint_67ffd912c9610f8ceb69fbfed2ee46908a1d4bcba43542f10eac24a50b0d8d11.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/useless_parens.rs
-expression: snapshot
 ---
 expression:
 [(builtins.pam or map)]

--- a/bin/tests/snapshots/useless_parens__lint_dbf237a5ac629f60efb6cc28b28986f3e8f38ab97c28857a2b369399afce1c36.snap
+++ b/bin/tests/snapshots/useless_parens__lint_dbf237a5ac629f60efb6cc28b28986f3e8f38ab97c28857a2b369399afce1c36.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/useless_parens.rs
-expression: snapshot
 ---
 expression:
 [(builtins.map)]

--- a/bin/tests/snapshots/useless_parens__lint_dbf237a5ac629f60efb6cc28b28986f3e8f38ab97c28857a2b369399afce1c36.snap
+++ b/bin/tests/snapshots/useless_parens__lint_dbf237a5ac629f60efb6cc28b28986f3e8f38ab97c28857a2b369399afce1c36.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/useless_parens.rs
-expression: "\"[(builtins.map)]\""
+expression: snapshot
+---
+expression:
+[(builtins.map)]
 ---
 [W08] Warning: These parentheses can be omitted
    ╭─[<temp_file_path>:1:2]

--- a/bin/tests/snapshots/useless_parens__lint_dbf237a5ac629f60efb6cc28b28986f3e8f38ab97c28857a2b369399afce1c36.snap
+++ b/bin/tests/snapshots/useless_parens__lint_dbf237a5ac629f60efb6cc28b28986f3e8f38ab97c28857a2b369399afce1c36.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/useless_parens.rs
 ---
-expression:
 [(builtins.map)]
 ---
 [W08] Warning: These parentheses can be omitted

--- a/bin/tests/snapshots/useless_parens__lint_e77035eacc5250b3a65353c52612eb4a05666249943f2d5c27329a9915a340a9.snap
+++ b/bin/tests/snapshots/useless_parens__lint_e77035eacc5250b3a65353c52612eb4a05666249943f2d5c27329a9915a340a9.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/useless_parens.rs
 ---
-expression:
 ({ f = 2; })
 ---
 [W08] Warning: These parentheses can be omitted

--- a/bin/tests/snapshots/useless_parens__lint_e77035eacc5250b3a65353c52612eb4a05666249943f2d5c27329a9915a340a9.snap
+++ b/bin/tests/snapshots/useless_parens__lint_e77035eacc5250b3a65353c52612eb4a05666249943f2d5c27329a9915a340a9.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/useless_parens.rs
-expression: "\"({ f = 2; })\""
+expression: snapshot
+---
+expression:
+({ f = 2; })
 ---
 [W08] Warning: These parentheses can be omitted
    ╭─[<temp_file_path>:1:1]

--- a/bin/tests/snapshots/useless_parens__lint_e77035eacc5250b3a65353c52612eb4a05666249943f2d5c27329a9915a340a9.snap
+++ b/bin/tests/snapshots/useless_parens__lint_e77035eacc5250b3a65353c52612eb4a05666249943f2d5c27329a9915a340a9.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/useless_parens.rs
-expression: snapshot
 ---
 expression:
 ({ f = 2; })

--- a/bin/tests/snapshots/useless_parens__lint_ed0b445d7f4db791ac8dcf41de7d3bc416d22cc4154b5a58ff82ce1fed6fd3c0.snap
+++ b/bin/tests/snapshots/useless_parens__lint_ed0b445d7f4db791ac8dcf41de7d3bc416d22cc4154b5a58ff82ce1fed6fd3c0.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/useless_parens.rs
 ---
-expression:
 let a = 0; in (null)
 ---
 [W08] Warning: These parentheses can be omitted

--- a/bin/tests/snapshots/useless_parens__lint_ed0b445d7f4db791ac8dcf41de7d3bc416d22cc4154b5a58ff82ce1fed6fd3c0.snap
+++ b/bin/tests/snapshots/useless_parens__lint_ed0b445d7f4db791ac8dcf41de7d3bc416d22cc4154b5a58ff82ce1fed6fd3c0.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/useless_parens.rs
-expression: "\"let a = 0; in (null)\""
+expression: snapshot
+---
+expression:
+let a = 0; in (null)
 ---
 [W08] Warning: These parentheses can be omitted
    ╭─[<temp_file_path>:1:15]

--- a/bin/tests/snapshots/useless_parens__lint_ed0b445d7f4db791ac8dcf41de7d3bc416d22cc4154b5a58ff82ce1fed6fd3c0.snap
+++ b/bin/tests/snapshots/useless_parens__lint_ed0b445d7f4db791ac8dcf41de7d3bc416d22cc4154b5a58ff82ce1fed6fd3c0.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/useless_parens.rs
-expression: snapshot
 ---
 expression:
 let a = 0; in (null)

--- a/bin/tests/snapshots/useless_parens__lint_f04dfa0b3c36c6f2489cba3b913db246cbacd0f646193435d7def64d8bbd9b10.snap
+++ b/bin/tests/snapshots/useless_parens__lint_f04dfa0b3c36c6f2489cba3b913db246cbacd0f646193435d7def64d8bbd9b10.snap
@@ -1,6 +1,5 @@
 ---
 source: bin/tests/useless_parens.rs
-expression: snapshot
 ---
 expression:
 let b = 0; in (b)

--- a/bin/tests/snapshots/useless_parens__lint_f04dfa0b3c36c6f2489cba3b913db246cbacd0f646193435d7def64d8bbd9b10.snap
+++ b/bin/tests/snapshots/useless_parens__lint_f04dfa0b3c36c6f2489cba3b913db246cbacd0f646193435d7def64d8bbd9b10.snap
@@ -1,6 +1,9 @@
 ---
 source: bin/tests/useless_parens.rs
-expression: "\"let b = 0; in (b)\""
+expression: snapshot
+---
+expression:
+let b = 0; in (b)
 ---
 [W08] Warning: These parentheses can be omitted
    ╭─[<temp_file_path>:1:15]

--- a/bin/tests/snapshots/useless_parens__lint_f04dfa0b3c36c6f2489cba3b913db246cbacd0f646193435d7def64d8bbd9b10.snap
+++ b/bin/tests/snapshots/useless_parens__lint_f04dfa0b3c36c6f2489cba3b913db246cbacd0f646193435d7def64d8bbd9b10.snap
@@ -1,7 +1,6 @@
 ---
 source: bin/tests/useless_parens.rs
 ---
-expression:
 let b = 0; in (b)
 ---
 [W08] Warning: These parentheses can be omitted

--- a/macros/src/test.rs
+++ b/macros/src/test.rs
@@ -98,7 +98,9 @@ fn make_test(rule: &Ident, kind: TestKind, nix_expression: &Expr) -> proc_macro2
             let expression = #nix_expression;
             let stdout = _utils::test_cli(expression, #args).unwrap();
             let snapshot = format!("expression:\n{expression}\n---\n{stdout}");
-            insta::assert_snapshot!(#snap_name, snapshot);
+            insta::with_settings!({omit_expression => true}, {
+                insta::assert_snapshot!(#snap_name, snapshot);
+            });
         }
     }
 }

--- a/macros/src/test.rs
+++ b/macros/src/test.rs
@@ -97,7 +97,7 @@ fn make_test(rule: &Ident, kind: TestKind, nix_expression: &Expr) -> proc_macro2
         fn #test_ident() {
             let expression = #nix_expression;
             let stdout = _utils::test_cli(expression, #args).unwrap();
-            let snapshot = format!("expression:\n{expression}\n---\n{stdout}");
+            let snapshot = format!("{expression}\n---\n{stdout}");
             insta::with_settings!({omit_expression => true}, {
                 insta::assert_snapshot!(#snap_name, snapshot);
             });

--- a/macros/src/test.rs
+++ b/macros/src/test.rs
@@ -97,7 +97,8 @@ fn make_test(rule: &Ident, kind: TestKind, nix_expression: &Expr) -> proc_macro2
         fn #test_ident() {
             let expression = #nix_expression;
             let stdout = _utils::test_cli(expression, #args).unwrap();
-            insta::assert_snapshot!(#snap_name, stdout, &format!("{expression:?}"));
+            let snapshot = format!("expression:\n{expression}\n---\n{stdout}");
+            insta::assert_snapshot!(#snap_name, snapshot);
         }
     }
 }


### PR DESCRIPTION
Closes #1744

Previously, the expression field in snapshots was generated from the Rust source text, causing multi-line Nix expressions to appear as escaped one-liners like:

```
"{\n  foo.baz.bar1 = 1;\n  foo.baz.bar2 = 2;\n}\n"
```

This PR fixes that by embedding the Nix expression directly in the snapshot body using `format!`, so snapshots now render as:
```
expression:
{
  foo.baz.bar1 = 1;
  foo.baz.bar2 = 2;
}
---
```

Also upgrades `insta` from `*` to `1.46.3`.

