### PR TITLE
refactor: mark non-flake inputs with flake = false

### DIFF
--- a/flake-parts/dev-shell.nix
+++ b/flake-parts/dev-shell.nix
@@ -1,6 +1,6 @@
 { inputs, ... }:
 {
   imports = [
-    inputs.make-shell.flakeModules.default
+    "${inputs.make-shell}/flake-module.nix"
   ];
 }

--- a/flake-parts/fmt.nix
+++ b/flake-parts/fmt.nix
@@ -1,6 +1,6 @@
 { inputs, ... }:
 {
-  imports = [ inputs.treefmt.flakeModule ];
+  imports = [ "${inputs.treefmt}/flake-module.nix" ];
 
   perSystem =
     psArgs@{ pkgs, ... }:

--- a/flake-parts/git-hooks.nix
+++ b/flake-parts/git-hooks.nix
@@ -1,6 +1,6 @@
 { inputs, ... }:
 {
-  imports = [ inputs.git-hooks.flakeModule ];
+  imports = [ "${inputs.git-hooks}/flake-module.nix" ];
 
   gitignore = [
     "/.pre-commit-config.yaml"

--- a/flake.lock
+++ b/flake.lock
@@ -16,21 +16,6 @@
         "type": "github"
       }
     },
-    "flake-compat_dedupe": {
-      "locked": {
-        "lastModified": 1767039857,
-        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": [
@@ -52,17 +37,7 @@
       }
     },
     "git-hooks": {
-      "inputs": {
-        "flake-compat": [
-          "flake-compat_dedupe"
-        ],
-        "gitignore": [
-          "gitignore_dedupe"
-        ],
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
+      "flake": false,
       "locked": {
         "lastModified": 1778507602,
         "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
@@ -77,32 +52,8 @@
         "type": "github"
       }
     },
-    "gitignore_dedupe": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1762808025,
-        "narHash": "sha256-XmjITeZNMTQXGhhww6ed/Wacy2KzD6svioyCX7pkUu4=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "cb5e3fdca1de58ccbc3ef53de65bd372b48f567c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
     "make-shell": {
-      "inputs": {
-        "flake-compat": [
-          "flake-compat_dedupe"
-        ]
-      },
+      "flake": false,
       "locked": {
         "lastModified": 1733933815,
         "narHash": "sha256-9JjM7eT66W4NJAXpGUsdyAFXhBxFWR2Z9LZwUa7Hli0=",
@@ -133,21 +84,15 @@
     "root": {
       "inputs": {
         "files": "files",
-        "flake-compat_dedupe": "flake-compat_dedupe",
         "flake-parts": "flake-parts",
         "git-hooks": "git-hooks",
-        "gitignore_dedupe": "gitignore_dedupe",
         "make-shell": "make-shell",
         "nixpkgs": "nixpkgs",
         "treefmt": "treefmt"
       }
     },
     "treefmt": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
+      "flake": false,
       "locked": {
         "lastModified": 1780220602,
         "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",

--- a/flake.nix
+++ b/flake.nix
@@ -10,32 +10,30 @@
       inputs.nixpkgs-lib.follows = "nixpkgs";
     };
 
-    nixpkgs.url = "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz";
+    nixpkgs = {
+      url = "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz";
+      flake = false;
+    };
+
     git-hooks = {
       url = "github:cachix/git-hooks.nix";
-      inputs = {
-        nixpkgs.follows = "nixpkgs";
-        gitignore.follows = "gitignore_dedupe";
-        flake-compat.follows = "flake-compat_dedupe";
-      };
+      flake = false;
     };
+
     make-shell = {
       url = "github:nicknovitski/make-shell";
-      inputs.flake-compat.follows = "flake-compat_dedupe";
+      flake = false;
     };
+
     files = {
       url = "github:mightyiam/files";
       flake = false;
     };
+
     treefmt = {
       url = "github:numtide/treefmt-nix";
-      inputs.nixpkgs.follows = "nixpkgs";
+      flake = false;
     };
-    gitignore_dedupe = {
-      url = "github:hercules-ci/gitignore.nix";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-    flake-compat_dedupe.url = "github:edolstra/flake-compat";
   };
   outputs =
     inputs:

--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,6 @@
       url = "github:mightyiam/files";
       flake = false;
     };
-
     treefmt = {
       url = "github:numtide/treefmt-nix";
       flake = false;

--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,6 @@
       url = "github:cachix/git-hooks.nix";
       flake = false;
     };
-
     make-shell = {
       url = "github:nicknovitski/make-shell";
       flake = false;

--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,6 @@
       url = "github:nicknovitski/make-shell";
       flake = false;
     };
-
     files = {
       url = "github:mightyiam/files";
       flake = false;


### PR DESCRIPTION
This PR marks inputs that don't need to be flakes with `flake = false`, avoiding unnecessary evaluation of their `flake.nix`, fetching of their transitive inputs, and exposure of their flake outputs.

**Inputs marked** `flake = false`:

- `nixpkgs` — used only via `import inputs.nixpkgs { ... }`
- `git-hooks` — imported directly via `flake-module.nix`
- `make-shell` — imported directly via `flake-module.nix`
- `files` — imported directly via `flake-module.nix`
- `treefmt` — imported directly via `flake-module.nix`

`flake-parts` remains a flake since `mkFlake` is only available via its flake output.