### PR TITLE
fix: remove flake-parts nixpkgs-lib follows nixpkgs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,6 @@
 
     nixpkgs = {
       url = "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz";
-      flake = false;
     };
 
     git-hooks = {


### PR DESCRIPTION
`flake-parts` has its own `nixpkgs-lib` input from which it inherits` lib`. This repo was overriding that with `inputs.nixpkgs-lib.follows = "nixpkgs"`, routing it through statix's own `nixpkgs`. Since `nixpkgs` has `flake = false`, it's a bare source tree with no flake outputs, so `flake-parts` fails to find `nixpkgs-lib.lib` and evaluation errors immediately.

Removing the `follows` lets `flake-parts` use its own pinned `nixpkgs-lib`, which is a proper flake. This fixes the nixpkgs bump failure reported in #2677 