### PR TITLE
chore: extract packages into packages/<name>.nix

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -1,44 +1,4 @@
 final: _prev: {
-  statix = final.rustPlatform.buildRustPackage {
-    pname = "statix";
-    version = "0.6.0-git";
-    src = final.lib.fileset.toSource {
-      root = ./.;
-      fileset = final.lib.fileset.unions [
-        (final.lib.fileset.fileFilter (
-          file:
-          final.lib.any final.lib.id [
-            (file.name == "Cargo.toml")
-            (file.hasExt "rs")
-            (file.hasExt "snap")
-          ]
-        ) ./.)
-        ./Cargo.lock
-        ./insta.yaml
-      ];
-    };
-    cargoLock.lockFile = ./Cargo.lock;
-    buildFeatures = [ "json" ];
-    meta = {
-      mainProgram = "statix";
-      description = "Lints and suggestions for the Nix programming language";
-      homepage = "https://github.com/molybdenumsoftware/statix";
-      license = final.lib.licenses.mit;
-    };
-  };
-
-  statix-vim =
-    let
-      pluginRoot = ./vim-plugin;
-    in
-    final.vimUtils.buildVimPlugin {
-      pname = "statix-vim";
-      version = "0.1.0-git";
-      src = final.lib.fileset.toSource {
-        root = pluginRoot;
-        fileset = final.lib.fileset.union (pluginRoot + "/plugin/statix.vim") (
-          pluginRoot + "/ftplugin/nix.vim"
-        );
-      };
-    };
+  statix = final.callPackage ./packages/statix.nix { };
+  statix-vim = final.callPackage ./packages/statix-vim.nix { };
 }

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,4 +1,4 @@
-final: _prev: {
-  statix = final.callPackage ./packages/statix.nix { };
-  statix-vim = final.callPackage ./packages/statix-vim.nix { };
+final: prev: {
+  statix = prev.callPackage ./packages/statix.nix { };
+  statix-vim = prev.callPackage ./packages/statix-vim.nix { };
 }

--- a/packages/statix-vim.nix
+++ b/packages/statix-vim.nix
@@ -1,0 +1,15 @@
+{
+  vimUtils,
+  lib,
+}:
+let
+  pluginRoot = ../vim-plugin;
+in
+vimUtils.buildVimPlugin {
+  pname = "statix-vim";
+  version = "0.1.0-git";
+  src = lib.fileset.toSource {
+    root = pluginRoot;
+    fileset = lib.fileset.union (pluginRoot + "/plugin/statix.vim") (pluginRoot + "/ftplugin/nix.vim");
+  };
+}

--- a/packages/statix.nix
+++ b/packages/statix.nix
@@ -1,0 +1,31 @@
+{
+  rustPlatform,
+  lib,
+}:
+rustPlatform.buildRustPackage {
+  pname = "statix";
+  version = "0.6.0-git";
+  src = lib.fileset.toSource {
+    root = ../.;
+    fileset = lib.fileset.unions [
+      (lib.fileset.fileFilter (
+        file:
+        lib.any lib.id [
+          (file.name == "Cargo.toml")
+          (file.hasExt "rs")
+          (file.hasExt "snap")
+        ]
+      ) ../.)
+      ../Cargo.lock
+      ../insta.yaml
+    ];
+  };
+  cargoLock.lockFile = ../Cargo.lock;
+  buildFeatures = [ "json" ];
+  meta = {
+    mainProgram = "statix";
+    description = "Lints and suggestions for the Nix programming language";
+    homepage = "https://github.com/molybdenumsoftware/statix";
+    license = lib.licenses.mit;
+  };
+}


### PR DESCRIPTION
Extracts the `statix` and `statix-vim` package definitions from `overlay.nix` into `packages/statix.nix` and `packages/statix-vim.nix respectively`, and calls each via `callPackage` in the overlay.