### PR TITLE
chore: switch to crate2nix

### DIFF
--- a/flake-parts/crate2nix.nix
+++ b/flake-parts/crate2nix.nix
@@ -1,0 +1,10 @@
+{ inputs, ... }:
+{
+  perSystem = _: {
+    nixpkgs.overlays = [
+      (_: prev: {
+        crate2nixTools = prev.callPackage "${inputs.crate2nix}/tools.nix" { };
+      })
+    ];
+  };
+}

--- a/flake-parts/rust.nix
+++ b/flake-parts/rust.nix
@@ -4,8 +4,10 @@
     { pkgs, ... }:
     {
       make-shells.default = {
-        inputsFrom = [ pkgs.statix ];
         packages = [
+          pkgs.cargo
+          pkgs.rustc
+          pkgs.clippy
           pkgs.bacon
           pkgs.cargo-insta
           pkgs.rust-analyzer

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "crate2nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1782759041,
+        "narHash": "sha256-2577vxyoBa8+ZRiXr3CuPtOuEtPRYsFPSZuEc/KI/80=",
+        "owner": "nix-community",
+        "repo": "crate2nix",
+        "rev": "5e1ecfd2d15b34ec90c2e51fdffbe8116595a767",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "crate2nix",
+        "type": "github"
+      }
+    },
     "files": {
       "flake": false,
       "locked": {
@@ -99,6 +115,7 @@
     },
     "root": {
       "inputs": {
+        "crate2nix": "crate2nix",
         "files": "files",
         "flake-parts": "flake-parts",
         "git-hooks": "git-hooks",

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,6 @@
 {
   nixConfig = {
     abort-on-warn = true;
-    allow-import-from-derivation = false;
   };
 
   inputs = {
@@ -10,6 +9,10 @@
       inputs.nixpkgs-lib.follows = "nixpkgs";
     };
 
+    crate2nix = {
+      url = "github:nix-community/crate2nix";
+      flake = false;
+    };
     import-tree = {
       url = "github:denful/import-tree";
       flake = false;

--- a/packages/statix.nix
+++ b/packages/statix.nix
@@ -1,47 +1,45 @@
 {
-  rustPlatform,
   lib,
-  clippy,
+  callPackage,
+  defaultCrateOverrides,
+  crate2nixTools,
   gitMinimal,
 }:
-rustPlatform.buildRustPackage {
-  pname = "statix";
-  version = "0.6.0-git";
-  src = lib.fileset.toSource {
-    root = ../.;
-    fileset = lib.fileset.unions [
-      (lib.fileset.fileFilter (
-        file:
-        lib.any lib.id [
-          (file.name == "Cargo.toml")
-          (file.hasExt "rs")
-          (file.hasExt "snap")
-        ]
-      ) ../.)
-      ../Cargo.lock
-      ../insta.yaml
-    ];
+let
+  cargoNix = crate2nixTools.generatedCargoNix {
+    name = "statix";
+    src = lib.fileset.toSource {
+      root = ../.;
+      fileset = lib.fileset.unions [
+        (lib.fileset.fileFilter (
+          file:
+          lib.any lib.id [
+            (file.name == "Cargo.toml")
+            (file.hasExt "rs")
+            (file.hasExt "snap")
+          ]
+        ) ../.)
+        ../Cargo.lock
+        ../insta.yaml
+      ];
+    };
   };
-  RUSTFLAGS = "-D warnings";
-
-  nativeBuildInputs = [ clippy ];
-
-  nativeCheckInputs = [ gitMinimal ];
-
-  checkPhase = ''
-    runHook preCheck
-
-    cargo clippy --all-targets --all-features
-    cargoCheckHook
-
-    runHook postCheck
-  '';
-
-  cargoLock.lockFile = ../Cargo.lock;
+  built = (callPackage cargoNix { }).workspaceMembers.statix.build.override {
+    runTests = true;
+    testInputs = [ gitMinimal ];
+    crateOverrides = defaultCrateOverrides // {
+      statix = _: {
+        useClippy = true;
+        capLints = "forbid";
+      };
+    };
+  };
+in
+built.overrideAttrs (_: {
   meta = {
     mainProgram = "statix";
     description = "Lints and suggestions for the Nix programming language";
     homepage = "https://github.com/molybdenumsoftware/statix";
     license = lib.licenses.mit;
   };
-}
+})


### PR DESCRIPTION
Switches the `statix` package build from `rustPlatform.buildRustPackage` to `crate2nix`, which builds each crate as a separate Nix derivation enabling more granular caching.

**Changes:**

- Adds `github:nix-community/crate2nix` as a `flake = false` input
- Threads `inputs` through the overlay so `crate2nixSrc` is available to `callPackage`
- Rewrites `packages/statix.nix` to use `tools.generatedCargoNix` (IFD). `Cargo.nix` is generated at build time rather than checked in
- Removes `allow-import-from-derivation` = false from `nixConfig` since IFD is now required

The `statix-vim` package is unaffected.