### PR TITLE
chore: use nixpkgs NixOS module in perSystem

### DIFF
--- a/flake-parts/nixpkgs.nix
+++ b/flake-parts/nixpkgs.nix
@@ -3,10 +3,8 @@
   perSystem =
     { system, ... }:
     {
-      _module.args.pkgs = import inputs.nixpkgs {
-        inherit system;
-        config = { };
-        overlays = [ (import (root + "/overlay.nix")) ];
-      };
+      imports = [ "${inputs.nixpkgs}/nixos/modules/misc/nixpkgs.nix" ];
+      nixpkgs.hostPlatform = { inherit system; };
+      nixpkgs.overlays = [ (import (root + "/overlay.nix")) ];
     };
 }


### PR DESCRIPTION
Converts `flake-parts/nixpkgs.nix` to use the NixOS nixpkgs module (`nixos/modules/misc/nixpkgs.nix`) instead of calling `import inputs.nixpkgs {}` directly. This allows overlays to be configured via `nixpkgs.overlays` from any flake-parts module independently, which is a precursor to adding the crate2nix overlay in its own dedicated module.