### PR TITLE
refactor: use CARGO_BIN_EXE_statix in test utils

### DIFF
--- a/bin/tests/_utils.rs
+++ b/bin/tests/_utils.rs
@@ -7,9 +7,7 @@ pub fn test_cli(expression: &str, args: &[&str]) -> anyhow::Result<String> {
     let mut fixture = NamedTempFile::with_suffix(".nix")?;
     fixture.write_all(expression.as_bytes())?;
 
-    let output = Command::new("cargo")
-        .arg("run")
-        .arg("--")
+    let output = Command::new(env!("CARGO_BIN_EXE_statix"))
         .args(args)
         .arg(fixture.path())
         .output()?;
@@ -23,9 +21,7 @@ pub fn test_cli(expression: &str, args: &[&str]) -> anyhow::Result<String> {
 
 #[allow(dead_code)]
 pub fn test_cli_stdin(input: &str, args: &[&str]) -> anyhow::Result<String> {
-    let mut child = Command::new("cargo")
-        .arg("run")
-        .arg("--")
+    let mut child = Command::new(env!("CARGO_BIN_EXE_statix"))
         .args(args)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())


### PR DESCRIPTION
Replaces `Command::new("cargo").arg("run").arg("--")` in `bin/tests/_utils.rs with Command::new(env!("CARGO_BIN_EXE_statix"))`, which uses the pre-built binary path set by Cargo at compile time.

This is the idiomatic approach for integration tests that invoke a binary, it avoids shelling out to `cargo run` at test time, which requires network access to fetch dependencies and doesn't work in sandboxed build environments like Nix. The `walk.rs` tests already used this pattern; this brings `_utils.rs` in line with it.