### PR TITLE
test: add tests for walker errors

### DIFF
--- a/bin/tests/walk.rs
+++ b/bin/tests/walk.rs
@@ -169,11 +169,11 @@ mod gitignored_files {
     }
 }
 
-mod missing_path {
-    use std::process::Command;
+mod error {
+    use std::{fs, process::Command};
 
     #[test]
-    fn errors_on_missing_path() {
+    fn missing_path() {
         let dir = tempfile::tempdir().unwrap();
         let output = Command::new(env!("CARGO_BIN_EXE_statix"))
             .current_dir(dir.path())
@@ -185,6 +185,32 @@ mod missing_path {
         let stderr = std::str::from_utf8(&output.stderr).unwrap();
         assert!(stderr.contains("config error: path error: file not found"));
         assert!(stderr.contains("does_not_exist.nix"));
+        assert!(output.status.success());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unreadable_file() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("file.nix");
+        fs::write(&path, "").unwrap();
+
+        let mut perms = fs::metadata(&path).unwrap().permissions();
+        perms.set_mode(0o222);
+        fs::set_permissions(&path, perms).unwrap();
+
+        let output = Command::new(env!("CARGO_BIN_EXE_statix"))
+            .current_dir(dir.path())
+            .arg("check")
+            .output()
+            .unwrap();
+
+        let stdout = std::str::from_utf8(&output.stdout).unwrap();
+        assert!(stdout.contains("file.nix` contains non-utf8"));
+
+        assert!(output.status.success());
     }
 }
 


### PR DESCRIPTION
As discussed in #2756, this PR adds tests to document current program

- when the path is wrong, it prints config error: path error: file not found: file.nix but exits successfully.
- when a file cannot be read (e.g., due to missing permissions), it catches the I/O error, warns that the file contains non-utf8 content, and exits successfully at the end.

more regarding those issues:
- in the first situation, making the program exit with an error code instead of success would simply be done by adding std::process::exit(1); in main.rs.
- in the second situation, it currently skips unreadable files (but continues to lint the other files). This skipping behavior is good, so keeping the exit code as success makes sense. However, just reporting a read error on the file would be much better than throwing the current inaccurate utf-8 warning. the goal for this second issue would just be to change the inaccurate "utf-8 error" to a better "cannot read file" warning, but otherwise leaving it as is. 

i believe the fix for those issues can wait since it is non that important and unrelated to #2756 (which do not change any of these behaviors)